### PR TITLE
Speed up comp report generation

### DIFF
--- a/pinval.qmd
+++ b/pinval.qmd
@@ -236,7 +236,7 @@ if (cache_files %>% sapply(file.exists) %>% all()) {
   training_data_prefix <- dvc_md5_hash %>% substr(1, 2)
   training_data_filename <- dvc_md5_hash %>% substr(3, nchar(dvc_md5_hash))
 
-  training_df <- open_dataset(
+  training_df <- read_parquet(
     glue::glue(
       "{base_dvc_url}/files/md5/{training_data_prefix}/{training_data_filename}"
     )
@@ -245,7 +245,6 @@ if (cache_files %>% sapply(file.exists) %>% all()) {
       meta_pin %in% pivoted_comp_df$comp_pin,
       meta_sale_document_num %in% pivoted_comp_df$comp_document_num
     ) %>%
-    collect() %>%
     mutate(property_address = loc_property_address %>% tolower() %>% str_to_title())
 
   # Load school district data, for use in translating geo IDs to names.


### PR DESCRIPTION
## Background

This PR makes a few small changes to the `pinval.qmd` doc to speed up report generation. The biggest performance improvements include:

* Disabling the `Connections` tab integration in noctua to prevent it from scanning for table schemas during connection setup
* Restricting the query that pulls school district names to only pull school data for the subject PIN and the comp PINs
* Querying comps from Athena rather than copying the data from S3 and then filtering them
   * I tried this for a few of the other queries, but this was the only one where it made a material difference

Testing these changes on the "past sale is a comp" PIN suggest a speedup of around 3x, from 180s generation time to 60s.

Closes #19.

## Future improvements

The remaining block that takes the longest to execute is the block that rehydrates training data from the DVC cache. This block takes 40s to execute for the "past sale is a comp" PIN, meaning that 2/3 of execution time is spent on this one block:

https://github.com/ccao-data/pinval/blob/aef7904c26ecb27d90022d5eaad9738e24e38738/pinval.qmd#L244-L256

I bet there's a way to speed this up, but I couldn't think of one. Any ideas?