### PR TITLE
Implement design edits from Data Team

### DIFF
--- a/pinval.qmd
+++ b/pinval.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Cook County Assessor’s Model Value Report (Experimental)"
 title-block-banner: "#294298"
-subtitle: "PIN: `r glue::glue('<a style=color:white;text-decoration:underline target=_blank href=https://www.cookcountyassessor.com/pin/{params$pin}>{ccao::pin_format_pretty(params$pin)}</a>')`"
+subtitle: "<b>PIN: `r glue::glue('<a style=color:white;text-decoration:underline target=_blank href=https://www.cookcountyassessor.com/pin/{params$pin}>{ccao::pin_format_pretty(params$pin)}</a>')`</b>"
 execute:
   echo: false
   warning: false
@@ -41,11 +41,11 @@ library(tidyr)
 library(tools)
 
 # Helper function to wrap a PIN in a link for display purposes
-link_pin <- function(pin) {
-  pretty_pin <- ccao::pin_format_pretty(pin)
+link_pin <- function(pin, display_text) {
+  text <- ifelse(!missing(display_text), display_text, ccao::pin_format_pretty(pin))
   return(
     glue::glue(
-      "<a target=_blank href=https://www.cookcountyassessor.com/pin/{pin}>{pretty_pin}</a>"
+      "<a target=_blank href=https://www.cookcountyassessor.com/pin/{pin}>{text}</a>"
     )
   )
 }
@@ -360,8 +360,9 @@ library(reactable)
 #
 # @param assessment_df Dataframe representing the chars for the subject parcel
 # @param comp_df Dataframe representing chars for the comps
+# @param parcel_is_multicard Boolean indicating a multicard property
 # @return Returns a list of htmltools elements that can be rendered using `tagList()`
-html_tags_for_report <- function(assessment_df, comp_df) {
+html_tags_for_report <- function(assessment_df, comp_df, parcel_is_multicard) {
   return(
     withTags(
       list(
@@ -370,13 +371,14 @@ html_tags_for_report <- function(assessment_df, comp_df) {
         h2("Characteristics"),
         property_char_table(assessment_df),
         h2("Top 5 comparable sales"),
-        comps_map(assessment_df, comp_df),
+        comps_map(assessment_df, comp_df, parcel_is_multicard),
         br(),
-        combined_char_table(assessment_df, comp_df),
-        subject_pin_sale_warning(comp_df),
+        combined_char_table(assessment_df, comp_df, parcel_is_multicard),
+        subject_pin_sale_warning(comp_df, parcel_is_multicard),
         h2("Summary"),
         avg_price_summary(comp_df),
-        pred_fmv_summary(assessment_df)
+        pred_fmv_summary(assessment_df, parcel_is_multicard),
+        mailed_value_warning(parcel_is_multicard)
       )
     )
   )
@@ -426,9 +428,14 @@ property_char_table <- function(df) {
 }
 
 # Helper function for generating a leaflet map of comparable sales
-comps_map <- function(assessment_df, comp_df) {
+comps_map <- function(assessment_df, comp_df, parcel_is_multicard) {
+  # Set the label of the subject property differently if it's multicard
+  property_label <- glue::glue("Subject {ifelse(parcel_is_multicard, 'card', 'property')}")
   # Define legend attributes for the comps
-  legend_labels <- c("Subject property", "Comparable sale")
+  legend_labels <- c(
+    property_label,
+    "Comparable sale"
+  )
   comp_color <- "#00cc00"
   circle_marker_styles <- "width: 13px; height: 13px; border-radius: 50%"
   legend_colors <- c(
@@ -461,7 +468,7 @@ comps_map <- function(assessment_df, comp_df) {
       label = if (any(comp_df$is_subject_pin_sale)) {
         NULL
       } else {
-        "Subject property"
+        property_label
       },
       labelOptions = if (any(comp_df$is_subject_pin_sale)) {
         NULL
@@ -479,7 +486,7 @@ comps_map <- function(assessment_df, comp_df) {
         NULL
       } else {
         paste0(
-          "<h5>Subject property</h5>",
+          "<h5>", property_label, "</h5>",
           "<b>Address</b>: ", property_address,
           "<br><b>PIN</b>: ", link_pin(meta_pin),
           "<br><b>Property class</b>: ", char_class,
@@ -518,7 +525,7 @@ comps_map <- function(assessment_df, comp_df) {
         # It would be nice to introduce a line break here, but it doesn't
         # seem like the R leaflet package accepts HTML or exposes an interface
         # for advanced label formatting
-        glue::glue("Subject property [{sale_price_short} ({sale_date})]"),
+        glue::glue("{property_label} [{sale_price_short} ({sale_date})]"),
         glue::glue("{sale_price_short} ({sale_date})")
       ),
       labelOptions = labelOptions(
@@ -532,7 +539,7 @@ comps_map <- function(assessment_df, comp_df) {
         "<h5>",
         ifelse(
           is_subject_pin_sale,
-          "Subject property",
+          property_label,
           paste0("Comp ", comp_num)
         ),
         "</h5>",
@@ -597,7 +604,7 @@ avg_price_summary <- function(df) {
 
 # Helper function for generating a string summary of the predicted value of
 # the subject property
-pred_fmv_summary <- function(df) {
+pred_fmv_summary <- function(df, parcel_is_multicard) {
   # Use the initial FMV since we don't care about distinguishing building
   # from land value in this context
   pred_fmv <- df$pred_card_initial_fmv
@@ -610,13 +617,32 @@ pred_fmv_summary <- function(df) {
         "Based on these and other sales, the model that ran on  ",
         format(metadata_df$final_model_run_date, "%B %d, %Y"),
         " predicted that the value of this ",
-        ifelse(parcel_is_multicard, "card", "home"),
+        ifelse(parcel_is_multicard, "card", "property"),
         " as of lien date January 1, ",
         format(metadata_df$final_model_run_date, "%Y"),
         " should be ",
         "<b>", pred_fmv %>% scales::dollar(), "</b>",
         " at ",
         "<b>", pred_fmv_per_sqft %>% scales::dollar(accuracy = 1), "/sq.ft.</b>",
+        "</p>"
+      )
+    )
+  )
+}
+
+# Helper function for generating a warning that mailed values can differ from
+# model values
+mailed_value_warning <- function(parcel_is_multicard) {
+  return(
+    HTML(
+      paste0(
+        "<p>",
+        "The model's predicted value for this ",
+        ifelse(parcel_is_multicard, "card", "property"), " ",
+        "is not necessarily the final valuation during a reassessment. ",
+        "Analysts at the Assessor's Office can review the model's predictions ",
+        "and make adjustments. To see this property's most recent valuation, ",
+        "visit the ", link_pin(params$pin, "Assessor's website"), ".",
         "</p>"
       )
     )
@@ -660,7 +686,7 @@ freeze_first_n_rows <- function(df, n = 2, rows_per_page = 10) {
 
 # Helper function for generating a table for comparing chars between the subject
 # property and its comps
-combined_char_table <- function(assessment_df, comp_df) {
+combined_char_table <- function(assessment_df, comp_df, parcel_is_multicard) {
   # Define a list of the most important characteristics to be displayed
   # first in the table
   top_chars <- c(
@@ -771,7 +797,10 @@ combined_char_table <- function(assessment_df, comp_df) {
         values_from = Value,
         names_prefix = "Comp "
       ) %>%
-      rename("Subj. prop." = "Comp 0") %>%
+      rename_with(
+        ~ ifelse(parcel_is_multicard, "Subject card", "Subject prop."),
+        matches("Comp 0")
+      ) %>%
       # Freeze the price char rows so that they are always visible in the table
       # even when viewing different pages
       freeze_first_n_rows(n = num_frozen_rows, rows_per_page = rows_per_page) %>%
@@ -807,12 +836,13 @@ combined_char_table <- function(assessment_df, comp_df) {
   )
 }
 
-subject_pin_sale_warning <- function(comp_df) {
+subject_pin_sale_warning <- function(comp_df, parcel_is_multicard) {
   if (any(comp_df$is_subject_pin_sale)) {
     return(
       HTML(
         paste0(
-          "<b>*</b> This comparable is a sale of the subject property. ",
+          "<b>*</b> This comparable is a sale of the subject ",
+          ifelse(parcel_is_multicard, "card", "property"), ". ",
           "The model typically weights these sales highly, even if they ",
           "are older than other comparable sales."
         )
@@ -872,7 +902,7 @@ if (parcel_is_multicard) {
             class = ifelse(card_num == 1, "tab-pane active", "tab-pane"),
             role = "tabpanel",
             "aria-labelledby" = glue::glue("tabset-1-{card_num}-tab"),
-            html_tags_for_report(assessment_card_df, comp_card_df)
+            html_tags_for_report(assessment_card_df, comp_card_df, TRUE)
           )
         )
       )
@@ -897,7 +927,7 @@ if (parcel_is_multicard) {
   )
 } else {
   # For single-card PINs, skip the tablist
-  html_tags <- html_tags_for_report(assessment_df, comp_df)
+  html_tags <- html_tags_for_report(assessment_df, comp_df, FALSE)
 }
 
 # Render the list of HTML tags


### PR DESCRIPTION
This PR implements all feedback from https://github.com/ccao-data/pinval/issues/21 except for one requested feature (we don't add a dot to comp markers since it would require custom icons).

I'll send an example report over Teams so you can use it to review the most recent design.