### PR TITLE
Use "estimate" instead of "prediction"

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,5 +12,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+      - name: Run pre-commit checks
+        uses: ccao-data/actions/pre-commit@main


### PR DESCRIPTION
This PR makes a small change based on team feedback (https://github.com/ccao-data/pinval/issues/26): Using "estimate" instead of "prediction" in all of our user-facing text.