### PR TITLE
Refactor ingest and data munging using dbt models

### DIFF
--- a/pinval.qmd
+++ b/pinval.qmd
@@ -112,28 +112,6 @@ if (cache_files %>% sapply(file.exists) %>% all()) {
       )
     )
 
-  # Load final model run date for the given year, which might be different
-  # from the run ID specified in the params object if the comps run was
-  # not the same as the final model run
-  # TODO: Potentially add this into another table for speed up?
-  
-  # Temp fix
-  final_model_run_date <- dbGetQuery(
-    conn = athena_conn,
-    # As above, the LIMIT here is defensive
-    glue::glue("
-      SELECT run_id
-      FROM model.final_model
-      WHERE year = '{str_sub(params$run_id, 1, 4)}'
-      AND type = 'res'
-      AND is_final
-      LIMIT 1
-    ")
-  ) %>%
-    pull(run_id) %>%
-    substr(1, 10) %>%
-    as.Date()
-
   # Load card-level assessment data to use as the base for joining all chars
   assessment_df <- dbGetQuery(
     conn = athena_conn,
@@ -158,6 +136,14 @@ if (cache_files %>% sapply(file.exists) %>% all()) {
 
   pred_pin_final_fmv_round <- assessment_df %>%
     pull(pred_pin_final_fmv_round)
+
+  # Load final model run date for the given year, which might be different
+  # from the run ID specified in the params object if the comps run was
+  # not the same as the final model run
+  final_model_run_date <-
+    assessment_df %>%
+    pull(final_model_run_date) %>%
+    as.Date()
 
   # Save model metadata to a dedicated list for ease of access.
   # Prefer a list to a dataframe since not all of the attribute values


### PR DESCRIPTION
This PR goes hand in hand with https://github.com/ccao-data/data-architecture/pull/793 and issue https://github.com/ccao-data/pinval/issues/34.  

The objective of this PR is to refactor data manipulation and speed up the report generation. The main results is a decrease of report generation time from **45s to 25s**. Some other considerations on speed:
- It seems like quarto ramp up time is about 3-5s
- The bulk of the time spent is athena queries, with each query varying between 2-5s
- I tried a simple table partition, which just made it slower. My guess is that it didn't help because the data is sufficiently small and/or I didn't choose a good column on which to partition
- My time estimates are based on reading the quarto `Background Jobs` tab in R, along with some testing I did with `tictoc()` on various queries




