### PR TITLE
Fix 2-PIN comparison doc to work with pre-2023 assessment data

### DIFF
--- a/reports/pin-comparison/pin_comparison.qmd
+++ b/reports/pin-comparison/pin_comparison.qmd
@@ -568,8 +568,6 @@ datatable(
 ```{r feature_comparison, out.width="90%"}
 char_fmt <- char %>%
   select(-primary_card) %>%
-  # Convert characteristic codes to human-readable values
-  ccao::vars_recode(code_type = "short") %>%
   # Convert everything to character so that we can
   # pivot and combine feature value columns
   mutate(across(everything(), as.character)) %>%


### PR DESCRIPTION
This uses model.assessment_card rather than an S3 query to download the PIN / card characteristics.

The changes between the two queries are only the fact that model.assessment_card has strings for characteristic values such as finished, rather than a numerical factor. (slight improvement).

This means we should be able to remove lines 571 / 572.

```
all_equal(new, old)
Different types for column `char_air`: character vs factor<2ad98>.
Different types for column `char_apts`: character vs factor<f1b36>.
Different types for column `char_attic_fnsh`: character vs factor<b17be>.
Different types for column `char_attic_type`: character vs factor<b17be>.
Different types for column `char_bsmt`: character vs factor<b4689>.
Different types for column `char_bsmt_fin`: character vs factor<b17be>.
Different types for column `char_ext_wall`: character vs factor<b4689>.
Different types for column `char_gar1_att`: character vs factor<2ad98>.
Different types for column `char_gar1_cnst`: character vs factor<b4689>.
Different types for column `char_gar1_size`: character vs factor<88317>.
Different types for column `char_heat`: character vs factor<b4689>.
Different types for column `char_porch`: character vs factor<2641b>.
Different types for column `char_roof_cnst`: character vs factor<eba52>.
Different types for column `char_tp_dsgn`: character vs factor<2ad98>.
Different types for column `char_type_resd`: character vs factor<696bb>.
```