### PR TITLE
Update Quarto report for 2025 model

### DIFF
--- a/pinval.qmd
+++ b/pinval.qmd
@@ -25,7 +25,7 @@ params:
   #   * Past sale is a comp: 14331000240000
   #
   # Good 2025 PINs for testing:
-  #   * Single card: 05333030320000
+  #   * Single card: 05274160070000
   #   * Small multicard: 05344260050000
   #   * Large multicard: 05343210140000
   #   * Past sale is a comp: 05333030300000


### PR DESCRIPTION
This PR updates the Quarto report to default to the 2025 model. In the process, it also streamlines the Quarto params to tie final models to years so that the user only has to set the `year` for the report they would like to generate and the doc will infer the correct model run ID based on the year.