### PR TITLE
Better handling for small multicards in Quarto report

### DIFF
--- a/pinval.qmd
+++ b/pinval.qmd
@@ -24,7 +24,7 @@ params:
   #   * Single card: 14051280390000
   #   * Multicard: 16251020210000
   #   * Past sale is a comp: 14331000240000
-  pin: "16251020210000"
+  pin: "14331000240000"
   num_comps: 5
 ---
 


### PR DESCRIPTION
This PR updates the Quarto report with better handling for post-2025 small (2-3 card) multicard parcels. Changes for these types of PINs include:

- Clearer text explaining the difference in valuation method for these types of PINs
- Only display comps and chars for the "frankencard" for the subject property
- Aggregate building square feet for the subject property
- Show the label "Combined Bldg. S.F" instead of "Bldg. S.F." anywhere in the report where we display building SF for the subject property

I tested this by running the following combinations of reports, and confirming that they look correct. If you'd like to inspect them too, let me know and I can upload them to the shared drive:

- 2025 single-card
- 2025 small multicard (2 cards)
- 2025 large multicard (4 cards)
- 2025 past sale is a comp
- 2024 small multicard (2 cards)

Connects https://github.com/ccao-data/pinval/issues/31.