### PR TITLE
Fix 2 pin comparison doc to use new 2-3 card comps/shaps

### DIFF
--- a/reports/pin-comparison/pin_comparison.qmd
+++ b/reports/pin-comparison/pin_comparison.qmd
@@ -1,7 +1,7 @@
 ---
 title: "PIN Comparison Doc"
 params:
-  run_id: "2025-02-11-charming-eric"
+  run_id: "2025-04-25-fancy-free-billy"
   pin1: "01011260760000"
   pin_1_card_num:
   pin2: "01012150080000"


### PR DESCRIPTION
The previous version worked with our updated comps/shaps. Since we structured it in this way, it adds a filter to ensure that it works with previous year models where COMPs and SHAPs come from specific cards.

One related, but probably inconsequential thing which was noted during QC was that not all final runs have rounded values for non-tri parcels. 

```
SELECT
  meta_triad_code,
  run_id,
  COUNT(*) AS null_pred_pin_final_fmv_round
FROM model.assessment_pin
WHERE run_id IN (
    '2025-02-11-charming-eric',
    '2022-04-27-keen-gabe',
    '2024-02-06-relaxed-tristan',
    '2024-03-17-stupefied-maya',
    '2023-03-14-clever-damani'
  )
  AND pred_pin_final_fmv_round IS NULL
GROUP BY (meta_triad_code, run_id)
```

Changes have been tested by using   run_id: "2024-03-17-stupefied-maya"
and switching   pin_1_card_num: between 1 and 2 and NULL.
This does not produce the correct comps join since doc_number was not included.

An updated comps run with 2024-06-18-calm-nathan works with the correct sales join, but doesn't have shaps enabled.