### PR TITLE
Add stub for pinval workflow generation workflow

### DIFF
--- a/.github/workflows/generate-pinval.yaml
+++ b/.github/workflows/generate-pinval.yaml
@@ -9,4 +9,4 @@ jobs:
 
     steps:
       - name: Checkout repo code
-        uses: actions/checkout@v
+        uses: actions/checkout@v4


### PR DESCRIPTION
We add a template here so we can get the workflow file on the main branch to make development easier for https://github.com/ccao-data/pinval/issues/37