### PR TITLE
Use var labels at compile time, not runtime

### DIFF
--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -27,10 +27,6 @@
 </head>
 <body>
   {{ partial "banner/banner.html" . }}
-  <script>
-    /* Declare front matter var_labels as JS object */
-    const VAR_LABELS = {{ .Params.var_labels | jsonify | safeJS }};
-  </script>
 
   <!-- Body of the report -->
   <div class="container">
@@ -143,7 +139,7 @@
             role="tabpanel"
             aria-labelledby="card-{{ $index }}-tab"
           >
-            {{ template "card-content" (dict "card" $card "is_multicard" true) }}
+            {{ template "card-content" (dict "card" $card "var_labels" .Params.var_labels "is_multicard" true) }}
           </div>
           {{ end }}
         </div>
@@ -151,7 +147,7 @@
       {{ else }}
         <!-- Single-card: No tabs required -->
         {{ $card := index .Params.cards 0 }}
-        {{ template "card-content" (dict "card" $card "is_multicard" false) }}
+        {{ template "card-content" (dict "card" $card "var_labels" .Params.var_labels "is_multicard" false) }}
       {{ end }}
 
       <h2>Final model estimate</h2>
@@ -292,8 +288,7 @@
         <!-- Regular rows -->
         {{ range $char := .card.predictors }}
         <tr>
-          <!-- Setting this up for the JS to later swap raw column name to human readable name -->
-          <td class="char-name" data-char="{{ $char }}">{{ $char }}</td>
+          <td>{{ index $.var_labels $char }}</td>
           <td>{{ index $.card.chars $char }}</td>
 
           {{ range $comp := $.card.comps }}
@@ -629,23 +624,6 @@
       // Trigger initial draw (forces first insert)
       dt.draw();
     }
-  </script>
-  <!-- JS block that updates raw column names to human readable -->
-  <script>
-  document.addEventListener("DOMContentLoaded", () => {
-    /* Replace each raw characteristic code with its pretty label */
-    const updateLabels = () => {
-      document.querySelectorAll(".characteristic-comparison-table .char-name")
-              .forEach(td => {
-                const key    = td.dataset.char;   // e.g. "char_beds"
-                const pretty = VAR_LABELS[key];   // e.g. "Bedrooms"
-                if (pretty) td.textContent = pretty;
-              });
-    };
-
-    updateLabels();
-    $('.characteristic-comparison-table').on('draw.dt', updateLabels);
-  });
   </script>
 </body>
 </html>


### PR DESCRIPTION
This PR is a small and quick branch off of https://github.com/ccao-data/pinval/pull/50 to demonstrate how we could use PINVAL characteristic labels at compile time instead of at runtime.

Note that there's still one problem I can't figure out: For some reason, characteristics in the table are getting alphabetized unexpectedly. I haven't dug too deep on this, but I'm going to take another crack at investigating it when I review #50 more deeply.