### PR TITLE
Factor out `list-townships` logic from workflow to script file

### DIFF
--- a/.github/workflows/generate-pinval.yaml
+++ b/.github/workflows/generate-pinval.yaml
@@ -58,54 +58,41 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Mask sensitive information
+        run: echo "::add-mask::${{ secrets.AWS_ACCOUNT_ID }}"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: scripts/generate_pinval/uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: scripts/generate_pinval/.python-version
+
+      - name: Create uv virtual environment
+        run: uv venv
+        working-directory: scripts/generate_pinval
+
+      - name: Install Python requirements
+        run: uv pip install .
+        working-directory: scripts/generate_pinval
+
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
           aws-region: us-east-1
 
-      - name: Mask sensitive information
-        run: echo "::add-mask::${{ secrets.AWS_ACCOUNT_ID }}"
-
-      - name: Install Python dependencies for discovery
-        run: |
-          python -m pip install --upgrade pip
-          pip install pyathena pandas
-
       - name: Collect township codes (or fallback)
         id: set-matrix
-        env:
-          RUN_ID: ${{ inputs.run_id }}
-          TRIAD: ${{ inputs.triad_name }}
         run: |
-          python - <<'PY'
-          import json, os, sys
-          from pyathena import connect
-
-          run_id = os.environ["RUN_ID"]
-          triad  = os.environ["TRIAD"].strip().lower()
-
-          # Defaults to a single empty shard if no triad is specified
-          codes = [""]
-
-          if triad:
-              sql = f"""
-                SELECT DISTINCT meta_township_code
-                FROM pinval.vw_assessment_card
-                WHERE run_id = '{run_id}'
-                  AND assessment_triad = '{triad}'
-                ORDER BY meta_township_code
-              """
-              codes = [row[0] for row in connect(region_name="us-east-1").cursor().execute(sql)]
-
-          matrix = json.dumps({"township": codes})
-          count  = len(codes)
-          print(f"matrix={matrix}")
-
-          with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
-              fh.write(f"matrix={matrix}\n")
-              fh.write(f"count={count}\n")
-          PY
+          python3 scripts/generate_pinval/list_townships.py \
+            --run_id "${{ inputs.run_id }}" \
+            --triad "${{ inputs.triad_name }}" \
+            --write-github-output
 
 ###############################################################################
 # Generate PINVAL reports for a triad or explicit PINs
@@ -132,7 +119,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          cache-dependency-glob: uv.lock
+          cache-dependency-glob: scripts/generate_pinval/uv.lock
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ cache/
 
 # Ignore scratch documents
 scratch*.*
+
+# Python files
+*.pyc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,16 @@ repos:
       args: ['--fix=no']
     - id: trailing-whitespace
       exclude: activate.R
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.12.0
+  hooks:
+    # Python linter. Ruff recommends running this before the formatter to
+    # avoid conflicts when using the --fix flag
+    - id: ruff
+      args:
+        - --fix
+    # Formatter
+    - id: ruff-format
 - repo: local
   hooks:
     - id: forbid-to-commit

--- a/scripts/generate_pinval/constants.py
+++ b/scripts/generate_pinval/constants.py
@@ -1,0 +1,8 @@
+"""Constants that are shared between scripts in this module"""
+
+# Valid assessment triads
+TRIAD_CHOICES: tuple[str, ...] = ("city", "north", "south")
+
+# Temporary solution for run_id mapping, a problem that occurs when the model run_id
+# differs between the model values and the comps
+RUN_ID_MAP = {"2025-02-11-charming-eric": "2025-04-25-fancy-free-billy"}

--- a/scripts/generate_pinval/generate_pinval.py
+++ b/scripts/generate_pinval/generate_pinval.py
@@ -25,6 +25,7 @@ import os
 import subprocess as sp
 import gc
 import time
+import typing
 from pathlib import Path
 
 import numpy as np
@@ -32,7 +33,6 @@ import pandas as pd
 import orjson
 from pyathena import connect
 from pyathena.pandas.cursor import PandasCursor
-from pyathena.pandas.util import as_pandas
 
 import ccao
 
@@ -43,9 +43,8 @@ TRIAD_CHOICES: tuple[str, ...] = ("city", "north", "south")
 
 # Temporary solution for run_id mapping, a problem that occurs when the model run_id
 # differs between the model values and the comps
-RUN_ID_MAP = {
-    "2025-02-11-charming-eric": "2025-04-25-fancy-free-billy"
-}
+RUN_ID_MAP = {"2025-02-11-charming-eric": "2025-04-25-fancy-free-billy"}
+
 
 def parse_args() -> argparse.Namespace:
     """Parse command‑line arguments and perform basic validation."""
@@ -58,7 +57,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--run-id",
         required=True,
-        choices=list(RUN_ID_MAP.keys()), # Temporarily limits run_ids to those in the map
+        choices=list(
+            RUN_ID_MAP.keys()
+        ),  # Temporarily limits run_ids to those in the map
         help="Model run‑ID used by the Athena PINVAL tables (e.g. 2025-02-11-charming-eric)",
     )
 
@@ -101,6 +102,7 @@ def parse_args() -> argparse.Namespace:
 
     return args
 
+
 # Declare functions
 # ────────────────────────────────────────────────────────────────────────────
 def pin_pretty(raw_pin: str) -> str:
@@ -129,10 +131,11 @@ def _clean_predictors(raw: np.ndarray | list | str) -> list[str]:
 
     return [p.strip() for p in txt.split(",") if p.strip()]
 
+
 def build_front_matter(
     df_target_pin: pd.DataFrame,
     df_comps: pd.DataFrame,
-    pretty_fn: Callable[[str], str],
+    pretty_fn: typing.Callable[[str], str],
 ) -> dict:
     """
     Assemble the front-matter dict for **one PIN**.
@@ -155,9 +158,9 @@ def build_front_matter(
         "layout": "report",
         "title": "Cook County Assessor's Model Value Report (Experimental)",
         "assessment_year": tp["assessment_year"],
-        "final_model_run_date": pd.to_datetime(
-            tp["final_model_run_date"]
-        ).strftime("%B %d, %Y"),
+        "final_model_run_date": pd.to_datetime(tp["final_model_run_date"]).strftime(
+            "%B %d, %Y"
+        ),
         "pin": tp["meta_pin"],
         "pin_pretty": pin_pretty(tp["meta_pin"]),
         "pred_pin_final_fmv_round": f"${tp['pred_pin_final_fmv_round']:,.2f}",
@@ -175,15 +178,9 @@ def build_front_matter(
             .reset_index(drop=True)
         )
 
-        # Clean predictor names
-        preds_raw = _clean_predictors(card_df["model_predictor_all_name"])
-        preds_pretty = [pretty_fn(p) for p in preds_raw]
-
         # Add all of the feature columns to the card
         subject_chars = {
-            pred: card_df[pred]
-            for pred in preds_cleaned
-            if pred in card_df
+            pred: card_df[pred] for pred in preds_cleaned if pred in card_df
         }
 
         # Comps
@@ -195,7 +192,7 @@ def build_front_matter(
                 "pin_pretty": pin_pretty(comp["comp_pin"]),
                 "is_subject_pin_sale": comp["is_subject_pin_sale"],
                 "sale_price": f"${float(comp['meta_sale_price']):,.0f}",
-                "sale_price_short": comp['sale_price_short'],
+                "sale_price_short": comp["sale_price_short"],
                 "sale_price_per_sq_ft": f"${float(comp['sale_price_per_sq_ft']):,.0f}",
                 "sale_date": comp["sale_month_year"],
                 "document_num": comp["comp_document_num"],
@@ -216,11 +213,11 @@ def build_front_matter(
 
         comp_summary = {
             "sale_year_range_prefix": (
-                "between"
-                if " and " in comps_df["sale_year_range"].iloc[0]
-                else "in"
+                "between" if " and " in comps_df["sale_year_range"].iloc[0] else "in"
             ),
-            "sale_year_range": comps_df["sale_year_range"].iloc[0] if not comps_df.empty else "",
+            "sale_year_range": comps_df["sale_year_range"].iloc[0]
+            if not comps_df.empty
+            else "",
             "avg_sale_price": "${:,.0f}".format(sale_prices.mean()),
             "avg_price_per_sqft": "${:,.0f}".format(sqft_prices.mean()),
         }
@@ -236,24 +233,25 @@ def build_front_matter(
                         "municipality": card_df.get("loc_tax_municipality_name"),
                         "township": card_df["meta_township_code"],
                         "meta_nbhd_code": card_df["meta_nbhd_code"],
-                        "loc_school_elementary_district_name": card_df.get("school_elementary_district_name"),
-                        "loc_school_secondary_district_name": card_df.get("school_secondary_district_name"),
+                        "loc_school_elementary_district_name": card_df.get(
+                            "school_elementary_district_name"
+                        ),
+                        "loc_school_secondary_district_name": card_df.get(
+                            "school_secondary_district_name"
+                        ),
                         "loc_latitude": float(card_df["loc_latitude"]),
                         "loc_longitude": float(card_df["loc_longitude"]),
                     }.items()
                 },
                 "chars": subject_chars,
-                "has_subject_pin_sale": bool(
-                    comps_df["is_subject_pin_sale"].any()
-                ),
+                "has_subject_pin_sale": bool(comps_df["is_subject_pin_sale"].any()),
                 "pred_card_initial_fmv": "${:,.0f}".format(
                     card_df["pred_card_initial_fmv"]
                 ),
                 "pred_card_initial_fmv_per_sqft": "${:,.2f}".format(
                     card_df.get(
                         "pred_card_initial_fmv_per_sqft",
-                        card_df["pred_card_initial_fmv"]
-                        / card_df["char_bldg_sf"],
+                        card_df["pred_card_initial_fmv"] / card_df["char_bldg_sf"],
                     )
                 ),
                 "comps": comps_list,
@@ -262,7 +260,9 @@ def build_front_matter(
             }
         )
 
-    _format_dict_numbers(front, exclude_keys={"loc_latitude", "loc_longitude", "char_yrblt"})
+    _format_dict_numbers(
+        front, exclude_keys={"loc_latitude", "loc_longitude", "char_yrblt"}
+    )
     return front
 
 
@@ -286,7 +286,7 @@ def convert_to_builtin_types(obj) -> object:
         else:
             # keep multi-element arrays as lists
             return [convert_to_builtin_types(v) for v in obj.tolist()]
-    elif obj is pd.NA:          # pandas NA scalar
+    elif obj is pd.NA:  # pandas NA scalar
         return ""
     # Wrap NaN in quotes, otherwise the .nan breaks html map rendering
     elif isinstance(obj, (float, np.floating)) and np.isnan(obj):
@@ -331,13 +331,16 @@ def write_json(front_dict: dict, outfile: str | Path) -> None:
     )
     Path(outfile).write_text(json_bytes.decode("utf-8") + "\n", encoding="utf-8")
 
+
 def label_percent(s: pd.Series) -> pd.Series:
     """0.123 → '12%' (handles NaNs)."""
     return s.mul(100).round(0).astype("Int64").astype(str).str.replace("<NA>", "") + "%"
 
+
 def label_dollar(s: pd.Series) -> pd.Series:
     """45000 → '$45,000' (handles NaNs)."""
     return s.apply(lambda x: f"${x:,.0f}" if pd.notna(x) else "")
+
 
 def format_df(df: pd.DataFrame) -> pd.DataFrame:
     """
@@ -346,23 +349,35 @@ def format_df(df: pd.DataFrame) -> pd.DataFrame:
     return (
         df
         # Formate percentage columns
-        .pipe(lambda d: d.assign(**{
-            c: label_percent(d[c])
-            for c in d.filter(regex=r'^acs5_percent').columns
-        }))
+        .pipe(
+            lambda d: d.assign(
+                **{
+                    c: label_percent(d[c])
+                    for c in d.filter(regex=r"^acs5_percent").columns
+                }
+            )
+        )
         # Round up all numeric columns except for geo cols needed for mapping
-        .pipe(lambda d: d.assign(**{
-            c: d[c].round(2)
-            for c in d.select_dtypes(include='number').columns
-            if c not in {"loc_latitude", "loc_longitude"}
-        }))
+        .pipe(
+            lambda d: d.assign(
+                **{
+                    c: d[c].round(2)
+                    for c in d.select_dtypes(include="number").columns
+                    if c not in {"loc_latitude", "loc_longitude"}
+                }
+            )
+        )
         # Format $ columns
-            .pipe(lambda d: d.assign(**{
-                c: label_dollar(d[c])
-                for c in d.columns
-                if c == "acs5_median_household_renter_occupied_gross_rent"
-                or c.startswith("acs5_median_income")
-            }))
+        .pipe(
+            lambda d: d.assign(
+                **{
+                    c: label_dollar(d[c])
+                    for c in d.columns
+                    if c == "acs5_median_household_renter_occupied_gross_rent"
+                    or c.startswith("acs5_median_income")
+                }
+            )
+        )
     )
 
 
@@ -401,8 +416,6 @@ def _format_dict_numbers(obj, exclude_keys: set[str] = None):
     return _format_numeric(obj)
 
 
-
-
 def run_athena_query(cursor, sql: str, params: dict = None) -> pd.DataFrame:
     cursor.execute(sql, parameters=params)
     return cursor.as_pandas()
@@ -411,9 +424,7 @@ def run_athena_query(cursor, sql: str, params: dict = None) -> pd.DataFrame:
 def main() -> None:
     args = parse_args()
 
-    project_root = Path(
-        sp.getoutput("git rev-parse --show-toplevel")
-    )
+    project_root = Path(sp.getoutput("git rev-parse --show-toplevel"))
     os.chdir(project_root)
 
     # Athena connection (one per run)
@@ -442,13 +453,11 @@ def main() -> None:
 
         where_assessment = " AND ".join(assessment_clauses)
     else:
-        pins: list[str] = list(set(args.pin)) # de-dupe
+        pins: list[str] = list(set(args.pin))  # de-dupe
         pin_params = {f"pin{i}": p for i, p in enumerate(pins)}
         placeholders = ",".join(f"%({k})s" for k in pin_params)
 
-        where_assessment = (
-            f"run_id = %(run_id)s AND meta_pin IN ({placeholders})"
-        )
+        where_assessment = f"run_id = %(run_id)s AND meta_pin IN ({placeholders})"
         params_assessment = {"run_id": args.run_id, **pin_params}
 
     assessment_sql = f"""
@@ -458,13 +467,13 @@ def main() -> None:
     """
 
     print("Querying data from Athena ...")
-    df_assessment_all = format_df(run_athena_query(cursor, assessment_sql, params_assessment))
+    df_assessment_all = format_df(
+        run_athena_query(cursor, assessment_sql, params_assessment)
+    )
     print("Shape of df_assessment_all:", df_assessment_all.shape)
 
     if df_assessment_all.empty:
-        raise ValueError(
-            "No assessment rows returned for the given parameters"
-        )
+        raise ValueError("No assessment rows returned for the given parameters")
 
     # Get the comps
     comps_run_id = RUN_ID_MAP[args.run_id]
@@ -495,9 +504,7 @@ def main() -> None:
 
     print("Shape of df_comps_all:", df_comps_all.shape)
     if df_comps_all.empty:
-        raise ValueError(
-            "No comps rows returned for the given parameters — aborting."
-        )
+        raise ValueError("No comps rows returned for the given parameters — aborting.")
 
     # Crosswalk for making column names human-readable
     model_vars: list[str] = ccao.vars_dict["var_name_model"].tolist()
@@ -507,12 +514,13 @@ def main() -> None:
         names_from="model",
         names_to="pretty",
         output_type="vector",
-        dictionary=ccao.vars_dict
+        dictionary=ccao.vars_dict,
     )
 
     key_map: dict[str, str] = dict(zip(model_vars, pretty_vars))
 
     PRESERVE = {"loc_latitude", "loc_longitude"}
+
     def pretty(k: str) -> str:
         return k if k in PRESERVE else key_map.get(k, k)
 
@@ -530,13 +538,14 @@ def main() -> None:
     del df_assessment_all
     del df_comps_all
     gc.collect()
-    print(f"Grouping by PIN took {end_time_dict_groupby - start_time_dict_groupby:.2f} seconds")
+    print(
+        f"Grouping by PIN took {end_time_dict_groupby - start_time_dict_groupby:.2f} seconds"
+    )
 
     # Iterate over each unique PIN and output frontmatter
     print("Iterating pins to generate frontmatter")
     start_time = time.time()
     for i, (pin, df_target) in enumerate(df_assessments_by_pin.items()):
-
         if i % 5000 == 0:
             print(f"Processing PIN {i + 1} of {len(df_assessments_by_pin)}")
 
@@ -551,7 +560,9 @@ def main() -> None:
         write_json(front, md_path)
 
     elapsed_time = time.time() - start_time
-    print(f"✓ Completed generating frontmatter for {len(df_assessments_by_pin)} PINs in {elapsed_time:.4f} seconds.")
+    print(
+        f"✓ Completed generating frontmatter for {len(df_assessments_by_pin)} PINs in {elapsed_time:.4f} seconds."
+    )
 
     # ------------------------------------------------------------------
     # Optional Hugo build

--- a/scripts/generate_pinval/generate_pinval.py
+++ b/scripts/generate_pinval/generate_pinval.py
@@ -8,12 +8,12 @@ be supplied.
 Examples
 --------
 Generate two specific PINs:
-    $ ./scripts/generate_pinval.py \
+    $ python3 generate_pinval.py \
           --run-id 2025-02-11-charming-eric \
           --pin 01011000040000 10112040080000
 
 Generate every PIN in the north triad:
-    $ ./scripts/generate_pinval.py \
+    $ python3 generate_pinval.py \
           --run-id 2025-02-11-charming-eric \
           --triad north
 """
@@ -28,24 +28,19 @@ import time
 import typing
 from pathlib import Path
 
+import ccao
 import numpy as np
 import pandas as pd
 import orjson
 from pyathena import connect
 from pyathena.pandas.cursor import PandasCursor
 
-import ccao
+from constants import RUN_ID_MAP, TRIAD_CHOICES
+
 
 # Argparse interface
 # ─────────────────────────
 # ───────────────────────────────────────────────────
-TRIAD_CHOICES: tuple[str, ...] = ("city", "north", "south")
-
-# Temporary solution for run_id mapping, a problem that occurs when the model run_id
-# differs between the model values and the comps
-RUN_ID_MAP = {"2025-02-11-charming-eric": "2025-04-25-fancy-free-billy"}
-
-
 def parse_args() -> argparse.Namespace:
     """Parse command‑line arguments and perform basic validation."""
 

--- a/scripts/generate_pinval/list_townships.py
+++ b/scripts/generate_pinval/list_townships.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+List township codes for a specific triad and model run ID.
+
+Examples
+--------
+
+Print an array of township codes:
+    $ python3 list_townhip_codes \
+        --run-id 2025-02-11-charming-eric \
+        --pin 01011000040000 10112040080000
+
+Write a matrix of township codes to the GITHUB_OUTPUT env var, for use in a
+workflow:
+    $ python3 list_townhip_codes \
+        --run-id 2025-02-11-charming-eric \
+        --pin 01011000040000 10112040080000 \
+        --write-github-output
+
+"""
+
+import argparse
+import json
+import os
+
+from pyathena import connect
+
+from constants import RUN_ID_MAP, TRIAD_CHOICES
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command‑line arguments and perform basic validation"""
+
+    parser = argparse.ArgumentParser(
+        description="List township codes for a triad and model run ID",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--run-id",
+        required=True,
+        choices=list(
+            RUN_ID_MAP.keys()
+        ),  # Temporarily limits run_ids to those in the map
+        help="Model run‑ID used by the Athena PINVAL tables (e.g. 2025-02-11-charming-eric)",
+    )
+
+    parser.add_argument(
+        "--triad",
+        required=False,
+        choices=TRIAD_CHOICES,
+        help="Generate reports for all PINs in this triad (mutually‑exclusive with --pin)",
+    )
+
+    parser.add_argument(
+        "--write-github-output",
+        action=argparse.BooleanOptionalAction,
+        help="Write output to the GITHUB_OUTPUT env var, for use in workflows",
+    )
+
+    args = parser.parse_args()
+
+    return args
+
+
+def get_township_codes(run_id: str, triad: str | None) -> list[str]:
+    """
+    Given a model run ID and a triad, return all the township codes for that
+    triad that were assessed in the model run.
+
+    Returns an empty list if no towns in the triad were assessed in the run.
+    """
+    codes = [""]
+
+    if triad:
+        sql = f"""
+        SELECT DISTINCT meta_township_code
+        FROM pinval.vw_assessment_card
+        WHERE run_id = '{run_id}'
+            AND assessment_triad = '{triad}'
+        ORDER BY meta_township_code
+        """
+        codes = [
+            row[0] for row in connect(region_name="us-east-1").cursor().execute(sql)
+        ]
+
+    return codes
+
+
+def main() -> None:
+    """Main entrypoint for the script"""
+    args = parse_args()
+    codes = get_township_codes(args.run_id, args.triad)
+
+    if args.write_github_output:
+        matrix = json.dumps({"township": codes})
+        count = len(codes)
+        print(f"matrix={matrix}")
+
+        with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+            fh.write(f"matrix={matrix}\n")
+            fh.write(f"count={count}\n")
+    else:
+        print(codes)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_pinval/list_townships.py
+++ b/scripts/generate_pinval/list_townships.py
@@ -4,19 +4,17 @@ List township codes for a specific triad and model run ID.
 
 Examples
 --------
-
-Print an array of township codes:
-    $ python3 list_townhip_codes \
+Print an array of township codes in the North tri for a model run :
+    $ python3 list_townships.py \
         --run-id 2025-02-11-charming-eric \
-        --pin 01011000040000 10112040080000
+        --triad north
 
 Write a matrix of township codes to the GITHUB_OUTPUT env var, for use in a
-workflow:
-    $ python3 list_townhip_codes \
+GitHub workflow:
+    $ python3 list_townships.py \
         --run-id 2025-02-11-charming-eric \
-        --pin 01011000040000 10112040080000 \
+        --triad north \
         --write-github-output
-
 """
 
 import argparse
@@ -42,14 +40,14 @@ def parse_args() -> argparse.Namespace:
         choices=list(
             RUN_ID_MAP.keys()
         ),  # Temporarily limits run_ids to those in the map
-        help="Model run‑ID used by the Athena PINVAL tables (e.g. 2025-02-11-charming-eric)",
+        help="Model run ID (e.g. 2025-02-11-charming-eric)",
     )
 
     parser.add_argument(
         "--triad",
         required=False,
         choices=TRIAD_CHOICES,
-        help="Generate reports for all PINs in this triad (mutually‑exclusive with --pin)",
+        help="List townships in this triad that were reassessed by the model run",
     )
 
     parser.add_argument(


### PR DESCRIPTION
This PR factors out the Python logic that we defined inline in the `list-townships` job in the `generate-pinval` workflow (#38), moving it to its own dedicated script file so that we can lint and format it (#64).

Closes #61.