### PR TITLE
Stop booleans from getting cast to strings

### DIFF
--- a/scripts/generate_pinval/generate_pinval.py
+++ b/scripts/generate_pinval/generate_pinval.py
@@ -261,7 +261,14 @@ def build_front_matter(
         )
 
     _format_dict_numbers(
-        front, exclude_keys={"loc_latitude", "loc_longitude", "char_yrblt"}
+        front,
+        exclude_keys={
+            "loc_latitude",
+            "loc_longitude",
+            "char_yrblt",
+            "has_subject_pin_sale",
+            "is_subject_pin_sale",
+        },
     )
     return front
 


### PR DESCRIPTION
When we added `_format_dict_numbers()` we weren't excluding `"has_subject_pin_sale"` and `"is_subject_pin_sale"`. This cast them to string type which screwed up the conditional flow in the html doc. This now works, and will be re-worked to be simpler in https://github.com/ccao-data/pinval/issues/62