### PR TITLE
Fix multi-card bug where values for characteristic column don't appear

### DIFF
--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -179,7 +179,7 @@
             role="tabpanel"
             aria-labelledby="card-{{ $index }}-tab"
           >
-            {{ template "card-content" (dict "card" $card "var_labels" .Params.var_labels "is_multicard" true) }}
+            {{ template "card-content" (dict "card" $card "var_labels" $.Params.var_labels "is_multicard" true) }}
           </div>
           {{ end }}
         </div>


### PR DESCRIPTION
In the multi-card scenario, the values for the characteristic column in the characteristics table in the html table are not appearing.

This PR resolves this bug.

Screenshot of problem: 
![multi_card_html_table_bug](https://github.com/user-attachments/assets/43fd9a16-20d6-468a-9c67-eb5ee0f172c6)
