### PR TITLE
Truncate 14-digit PINs for display

### DIFF
--- a/scripts/generate_pinval/generate_pinval.py
+++ b/scripts/generate_pinval/generate_pinval.py
@@ -494,11 +494,7 @@ def main() -> None:
 
     assessment_year = assessment_year_df.iloc[0]["assessment_year"]
 
-    assessment_clauses = [
-        "run_id = %(run_id)s",
-        # Temporary workaround for one broken row
-        "meta_card_num IS NOT NULL",
-    ]
+    assessment_clauses = ["run_id = %(run_id)s"]
     params_assessment = {"run_id": args.run_id}
 
     # Shard by township **only** in the assessment query


### PR DESCRIPTION
Small PR to fix a tiny problem I noticed in the Hugo reports: We're displaying full 14-digit PINs, even though no PIN that is eligible for a PINVAL report should use the last 4 digits. Truncating the last 4 digits keeps the characteristic table compact and matches the Hugo report to the Quarto report.

You can see the results for PIN `01014000360000` on the staging site.