### PR TITLE
Fix average comps sale price bug

### DIFF
--- a/scripts/generate_pinval/generate_pinval.py
+++ b/scripts/generate_pinval/generate_pinval.py
@@ -246,7 +246,6 @@ def build_front_matter(
                 "pin_pretty": pin_pretty(tp["meta_pin"]),
                 "card_num": int(card_num),
                 "char_class_detailed": card_df["char_class_detailed"],
-                "pin_num_cards": card_df["ap_meta_pin_num_cards"],
                 "location": {
                     k: v
                     for k, v in {
@@ -593,9 +592,6 @@ def main() -> None:
     )
 
     key_map: dict[str, str] = dict(zip(model_vars, pretty_vars))
-    # Manually define mapping for the "Combined Bldg. SF" label, which is not
-    # part of `ccao.vars_dict`
-    key_map["combined_bldg_sf"] = "Combined Bldg. Sq. Ft."
 
     PRESERVE = {"loc_latitude", "loc_longitude"}
 

--- a/scripts/generate_pinval/generate_pinval.py
+++ b/scripts/generate_pinval/generate_pinval.py
@@ -240,6 +240,7 @@ def build_front_matter(
             "avg_sale_price": comps_df["comps_avg_sale_price"].iloc[0],
             "avg_price_per_sqft": comps_df["comps_avg_price_per_sqft"].iloc[0],
         }
+
         # Complete the card
         front["cards"].append(
             {

--- a/scripts/generate_pinval/generate_pinval.py
+++ b/scripts/generate_pinval/generate_pinval.py
@@ -400,11 +400,11 @@ def format_df(df: pd.DataFrame, chars_recode=False) -> pd.DataFrame:
 
     # Generate comps summary stats needed for frontmatter
     if "meta_sale_price" in df.columns:
-        df["comps_avg_sale_price"] = df.groupby(["card", "pin"])[
+        df["comps_avg_sale_price"] = df.groupby(["pin", "card"])[
             "meta_sale_price"
         ].transform("mean")
     if "sale_price_per_sq_ft" in df.columns:
-        df["comps_avg_price_per_sqft"] = df.groupby(["card", "pin"])[
+        df["comps_avg_price_per_sqft"] = df.groupby(["pin", "card"])[
             "sale_price_per_sq_ft"
         ].transform("mean")
 

--- a/scripts/generate_pinval/generate_pinval.py
+++ b/scripts/generate_pinval/generate_pinval.py
@@ -160,21 +160,10 @@ def build_front_matter(
     pretty_fn : Callable[[str], str]
         Function that converts a raw model column name → human-readable label.
     """
-    special_multi = bool(df_target_pin["is_parcel_small_multicard"].iloc[0])
-
-    if special_multi:
-        # keep only the Frankencard already flagged by the view
-        df_target_pin = df_target_pin[df_target_pin["is_frankencard"]].copy()
 
     # Header
     tp = df_target_pin.iloc[0]  # all cards share the same PIN-level chars
     preds_cleaned: list[str] = _clean_predictors(tp["model_predictor_all_name"])
-
-    # swap out the original sqft column for the combined version
-    if special_multi:
-        preds_cleaned = [
-            "combined_bldg_sf" if p == "char_bldg_sf" else p for p in preds_cleaned
-        ]
 
     front: dict = {
         "layout": "report",
@@ -188,7 +177,6 @@ def build_front_matter(
         "pred_pin_final_fmv_round": tp["pred_pin_final_fmv_round"],
         "cards": [],
         "var_labels": {k: pretty_fn(k) for k in preds_cleaned},
-        "special_case_multi_card": special_multi,
     }
 
     # Exit early if this PIN is ineligible for a report, in which case we


### PR DESCRIPTION
When calculating the average sale price and sale price per square foot for the comparables, we were only grouping by `card`. When running the python script for more than one PIN, this caused the group by operation to grab the mean for all of the PINs with card "1" rather that just the comps for a single PIN, for example. In this PR we add `pin` as a grouping variable to fix this.