### PR TITLE
Refactor to use new simplified `pinval.vw_assessment_card` data model

### DIFF
--- a/hugo/layouts/ineligible.html
+++ b/hugo/layouts/ineligible.html
@@ -25,10 +25,10 @@
         </p>
         {{ else if eq .Params.reason_report_ineligible "non_regression_class" }}
         <p>
-          This property has class code <strong>{{ .Params.parcel_class }}</strong>.
-          {{ if .Params.parcel_class_description }}
+          This property has class code <strong>{{ .Params.char_class }}</strong>.
+          {{ if .Params.char_class_desc }}
             Properties with this code should fit the description
-            <strong>"{{ .Params.parcel_class_description }}"</strong>.
+            <strong>"{{ .Params.char_class_desc }}"</strong>.
           {{ end }}
         </p>
         <p>
@@ -41,7 +41,7 @@
           The Assessor did not reassess this home in
           {{ .Params.assessment_year }}. In {{ .Params.assessment_year }},
           the Assessor reassessed the <strong>{{ title .Params.assessment_triad_name }}</strong>
-          triad, but this home is in the <strong>{{ title .Params.parcel_triad_name }}</strong>
+          triad, but this home is in the <strong>{{ title .Params.meta_triad_name }}</strong>
           triad.
         </p>
         {{ else if eq .Params.reason_report_ineligible "missing_card" }}

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -181,7 +181,7 @@
           >
             {{ template "card-content"
             (dict "card" $card
-                  "var_labels" $.Params.var_labels
+                  "Params" $.Params
                   "is_multicard" true)}}
           </div>
           {{ end }}
@@ -192,7 +192,7 @@
         {{ $card := index .Params.cards 0 }}
         {{ template "card-content"
           (dict "card" $card
-          "var_labels" .Params.var_labels
+          "Params" .Params
           "is_multicard" false) }}
       {{ end }}
 
@@ -356,7 +356,7 @@
         <!-- Regular rows -->
         {{ range $char := .card.predictors }}
         <tr>
-          <td class="char-name">{{ index $.var_labels $char }}</td>
+          <td class="char-name">{{ index $.Params.var_labels $char }}</td>
           <td>{{ index $.card.chars $char }}</td>
 
           {{ range $comp := $.card.comps }}

--- a/scripts/generate_pinval/constants.py
+++ b/scripts/generate_pinval/constants.py
@@ -9,5 +9,5 @@ RUN_ID_MAP = {"2025-02-11-charming-eric": "2025-02-11-charming-eric"}
 
 # It's helpful to factor these tables out into shared constants because we often
 # need to switch to dev tables for testing
-PINVAL_ASSESSMENT_CARD_TABLE = "z_dev_jecochr_pinval.vw_assessment_card"
-PINVAL_COMP_TABLE = "z_dev_jecochr_pinval.vw_comp"
+PINVAL_ASSESSMENT_CARD_TABLE = "pinval.vw_assessment_card"
+PINVAL_COMP_TABLE = "pinval.vw_comp"

--- a/scripts/generate_pinval/constants.py
+++ b/scripts/generate_pinval/constants.py
@@ -1,8 +1,11 @@
 """Constants that are shared between scripts in this module"""
 
 # Temporary solution for run_id mapping, a problem that occurs when the model run_id
-# differs between the model values and the comps
-RUN_ID_MAP = {"2025-02-11-charming-eric": "2025-04-25-fancy-free-billy"}
+# differs between the model values and the comps.
+# Currently we don't need more than one run because comps and cards are using the same
+# final run ID, but we're keeping this map around with the expectation that we may
+# need it for a more permanent fix
+RUN_ID_MAP = {"2025-02-11-charming-eric": "2025-02-11-charming-eric"}
 
 # It's helpful to factor these tables out into shared constants because we often
 # need to switch to dev tables for testing

--- a/scripts/generate_pinval/constants.py
+++ b/scripts/generate_pinval/constants.py
@@ -6,5 +6,5 @@ RUN_ID_MAP = {"2025-02-11-charming-eric": "2025-04-25-fancy-free-billy"}
 
 # It's helpful to factor these tables out into shared constants because we often
 # need to switch to dev tables for testing
-PINVAL_ASSESSMENT_CARD_TABLE = "pinval.vw_assessment_card"
-PINVAL_COMP_TABLE = "pinval.vw_comp"
+PINVAL_ASSESSMENT_CARD_TABLE = "z_dev_jecochr_pinval.vw_assessment_card"
+PINVAL_COMP_TABLE = "z_dev_jecochr_pinval.vw_comp"

--- a/scripts/generate_pinval/constants.py
+++ b/scripts/generate_pinval/constants.py
@@ -3,3 +3,8 @@
 # Temporary solution for run_id mapping, a problem that occurs when the model run_id
 # differs between the model values and the comps
 RUN_ID_MAP = {"2025-02-11-charming-eric": "2025-04-25-fancy-free-billy"}
+
+# It's helpful to factor these tables out into shared constants because we often
+# need to switch to dev tables for testing
+PINVAL_ASSESSMENT_CARD_TABLE = "pinval.vw_assessment_card"
+PINVAL_COMP_TABLE = "pinval.vw_comp"

--- a/scripts/generate_pinval/generate_pinval.py
+++ b/scripts/generate_pinval/generate_pinval.py
@@ -605,7 +605,7 @@ def main() -> None:
     # Group dfs by PIN in dict for theoretically faster access
     df_assessments_by_pin = df_assessment_all.groupby("meta_pin")
     df_comps_by_pin = (
-        {} if df_comps_all.empty else dict(tuple(df_comps_all.groupby("meta_pin")))
+        {} if df_comps_all.empty else dict(tuple(df_comps_all.groupby("pin")))
     )
     end_time_dict_groupby = time.time()
 

--- a/scripts/generate_pinval/generate_pinval.py
+++ b/scripts/generate_pinval/generate_pinval.py
@@ -36,7 +36,7 @@ import orjson
 from pyathena import connect
 from pyathena.pandas.cursor import PandasCursor
 
-from constants import RUN_ID_MAP
+import constants
 
 
 # Argparse interface
@@ -54,7 +54,7 @@ def parse_args() -> argparse.Namespace:
         "--run-id",
         required=True,
         choices=list(
-            RUN_ID_MAP.keys()
+            constants.RUN_ID_MAP.keys()
         ),  # Temporarily limits run_ids to those in the map
         help="Model run‑ID used by the Athena PINVAL tables (e.g. 2025-02-11-charming-eric)",
     )
@@ -528,7 +528,7 @@ def main() -> None:
 
     assessment_sql = f"""
         SELECT *
-        FROM pinval.vw_assessment_card
+        FROM {constants.PINVAL_ASSESSMENT_CARD_TABLE}
         WHERE {where_assessment}
     """
 
@@ -545,15 +545,15 @@ def main() -> None:
         )
 
     # Get the comps
-    if (comps_run_id := RUN_ID_MAP.get(args.run_id)) is None:
+    if (comps_run_id := constants.RUN_ID_MAP.get(args.run_id)) is None:
         raise ValueError(f"No comps run ID found for assessment run ID {args.run_id}")
 
     comps_sql = f"""
         SELECT comp.*
-        FROM pinval.vw_comp AS comp
+        FROM {constants.PINVAL_COMP_TABLE} AS comp
         INNER JOIN (
             SELECT DISTINCT meta_pin
-            FROM pinval.vw_assessment_card
+            FROM {constants.PINVAL_ASSESSMENT_CARD_TABLE}
             WHERE {where_assessment}
         ) AS card
           ON comp.pin = card.meta_pin

--- a/scripts/generate_pinval/resolve_model_metadata.py
+++ b/scripts/generate_pinval/resolve_model_metadata.py
@@ -105,10 +105,10 @@ def get_township_codes(
             .cursor()
             .execute(
                 """
-                    SELECT DISTINCT parcel_township_code
+                    SELECT DISTINCT meta_township_code
                     FROM pinval.vw_assessment_card
-                    WHERE model_run_id = %(run_id)s
-                    ORDER BY parcel_township_code
+                    WHERE run_id = %(run_id)s
+                    ORDER BY meta_township_code
                 """,
                 {"run_id": run_id},
             )

--- a/scripts/generate_pinval/resolve_model_metadata.py
+++ b/scripts/generate_pinval/resolve_model_metadata.py
@@ -15,6 +15,8 @@ import os
 from pyathena import connect
 from pyathena.cursor import DictCursor
 
+import constants
+
 
 def parse_args() -> argparse.Namespace:
     """Parse command‑line arguments and perform basic validation"""
@@ -104,9 +106,9 @@ def get_township_codes(
             for row in connect(region_name="us-east-1")
             .cursor()
             .execute(
-                """
+                f"""
                     SELECT DISTINCT meta_township_code
-                    FROM pinval.vw_assessment_card
+                    FROM {constants.PINVAL_ASSESSMENT_CARD_TABLE}
                     WHERE run_id = %(run_id)s
                     ORDER BY meta_township_code
                 """,


### PR DESCRIPTION
This PR updates our Hugo report generation code to handle the changes to the `pinval.vw_assessment_card` data model that we're making in https://github.com/ccao-data/data-architecture/pull/856.

In addition, we fold in one small change to improve the experience of testing changes to the data model: Factoring out constants for `PINVAL_ASSESSMENT_CARD_TABLE` and `PINVAL_COMP_TABLE`. By centralizing the references to these two tables, we can more easily change them when we need to test a corresponding change in `data-architecture`.

See PIN `06171140020000` on the staging site for an example of a deployed report.

Connects https://github.com/ccao-data/data-architecture/issues/855.