### PR TITLE
Improve map UX on mobile

### DIFF
--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -487,6 +487,9 @@
       const map = L.map(
         mapId,
         {
+          // Disable single-finger scroll interactions on mobile. Because
+          // touchZoom is enabled by default, the user will still be able to
+          // use two fingers to scroll and zoom
           dragging: !L.Browser.mobile,
           tap: !L.Browser.mobile
         }
@@ -536,6 +539,10 @@
           propertyLabel,
           {
             permanent: true,
+            // Propagate click events from the marker to its tooltip so that
+            // users can open the detail popup by clicking on the tooltip.
+            // This is particularly helpful on mobile since it can be hard
+            // to tap precisely on the circle marker
             interactive: true,
             direction: "top",
             offset: [0, -4],
@@ -634,7 +641,7 @@
       };
       legend.addTo(map);
 
-      // Add note control
+      // Add note control on mobile with prompt to use two fingers on the map
       if (L.Browser.mobile) {
         const noteControl = L.control({ position: "topright" });
         noteControl.onAdd = function() {
@@ -650,7 +657,7 @@
       }
 
       // Hide the note control whenever a popup is displayed, since otherwise
-      // the note control will obscure the popup
+      // the note control can obscure the popup
       const noteControlDiv = document.querySelector(".leaflet-control.info.note");
       map.on("popupopen", function() {
         if (noteControlDiv) noteControlDiv.style.display = "none";

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -287,6 +287,7 @@
 
   <!-- Comp map -->
   <h2 class="mb-3">Top 5 Most Important Sales</h2>
+  <p>Tap or click on a home to see more details.</p>
   <div
     id="map-{{ if .is_multicard }}{{ .card.card_num }}{{ else }}main{{ end }}"
     class="map-container"
@@ -483,7 +484,13 @@
       const cardData = mapData[cardIndex];
 
       // Create map centered on subject property
-      const map = L.map(mapId).setView(
+      const map = L.map(
+        mapId,
+        {
+          dragging: !L.Browser.mobile,
+          tap: !L.Browser.mobile
+        }
+      ).setView(
         [cardData.location.loc_latitude, cardData.location.loc_longitude],
         14
       );
@@ -529,6 +536,7 @@
           propertyLabel,
           {
             permanent: true,
+            interactive: true,
             direction: "top",
             offset: [0, -4],
             className: "subject-tooltip"
@@ -574,6 +582,7 @@
           tooltipText,
           {
             permanent: true,
+            interactive: true,
             direction: "top",
             offset: [0, -4],
             className: "comp-tooltip"
@@ -626,17 +635,19 @@
       legend.addTo(map);
 
       // Add note control
-      const noteControl = L.control({ position: "topright" });
-      noteControl.onAdd = function() {
-        const div = L.DomUtil.create("div", "info note");
-        div.innerHTML = `
-          <div style="background-color: white; padding: 5px 10px; border-radius: 5px; box-shadow: 0 0 15px rgba(0,0,0,0.2);">
-            Tap or click on a dot for more details
-          </div>
-        `;
-        return div;
-      };
-      noteControl.addTo(map);
+      if (L.Browser.mobile) {
+        const noteControl = L.control({ position: "topright" });
+        noteControl.onAdd = function() {
+          const div = L.DomUtil.create("div", "info note");
+          div.innerHTML = `
+            <div style="background-color: white; padding: 5px 10px; border-radius: 5px; box-shadow: 0 0 15px rgba(0,0,0,0.2);">
+              Use two fingers to scroll or zoom the map
+            </div>
+          `;
+          return div;
+        };
+        noteControl.addTo(map);
+      }
 
       // Fit bounds with a small buffer
       const boundsPadding = 0.001;

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -649,6 +649,15 @@
         noteControl.addTo(map);
       }
 
+      // Hide the note control whenever a popup is displayed, since otherwise
+      // the note control will obscure the popup
+      const noteControlDiv = document.querySelector(".leaflet-control.info.note");
+      map.on("popupopen", function() {
+        if (noteControlDiv) noteControlDiv.style.display = "none";
+      }).on("popupclose", function() {
+        if (noteControlDiv) noteControlDiv.style.display = "";
+      });
+
       // Fit bounds with a small buffer
       const boundsPadding = 0.001;
       bounds._southWest.lat -= boundsPadding;


### PR DESCRIPTION
This PR makes a few small improvements to the map user experience on mobile, based on the work we started in #73:

1. Disable Leaflet [`dragging`](https://leafletjs.com/reference.html#map-dragging) and `tap` interactions so that the user can scroll past the map when scrolling with one finger
    - I can't actually find docs for the `tap` option, but many people on StackExchange seem to think [this GitHub comment](https://github.com/Leaflet/Leaflet/issues/5425#issuecomment-342055520) is authoritative, and it includes `tap: false` 
3. Tweak the map control infobox to prompt the user to use two fingers to scroll or zoom the map
4. Hide the map control infobox when a popup is open, so the map control infobox doesn't obscure the popup
5. Make the map marker tooltips interactive so they display the popup when clicked or tapped, which expands the area that a mobile user can tap to see a popup

These changes are deployed for PIN 01011000040000 on the staging site.

Closes #71.


 