### PR TITLE
Improve characteristic comparison table UX

### DIFF
--- a/hugo/layouts/_partials/head/styles.html
+++ b/hugo/layouts/_partials/head/styles.html
@@ -48,14 +48,6 @@
     height: 24px;
   }
 
-  .frozen-row {
-    background: rgba(0, 0, 0, 0.05);
-  }
-
-  .frozen-row-bottom-border {
-    border-bottom: 1px solid rgb(182, 182, 182);
-  }
-
   .char-name {
     font-weight: 600;
   }

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -702,20 +702,20 @@
       const dt = $table.DataTable({
         paging: false,
         scrollX: true,
-        fixedColumns: true,
+        fixedColumns: !L.Browser.mobile,
         fixedHeader: true,
         searching: true,
         info: true,
         ordering: false,
         lengthChange: false,
         language: {
-          search: "Filter characteristics:",
+          search: "<b>Search</b> characteristics:",
           info: "Scroll to the right to see more sales ➜"
         },
         layout: {
-          topStart: "search",
+          bottomStart: "search",
           topEnd: L.Browser.mobile ? "info" : null,
-          bottomStart: null
+          topStart: null
         }
       });
 

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -316,29 +316,27 @@
         </tr>
       </thead>
       <tbody>
-        <!-- These rows will be frozen at the top -->
-        <tr class="frozen-row">
+        <tr>
           <td class="char-name">Sale Price</td>
           <td></td>
           {{ range $index, $comp := .card.comps }}
           <td>{{ $comp.sale_price }}</td>
           {{ end }}
         </tr>
-        <tr class="frozen-row">
+        <tr>
           <td class="char-name">Sale $/sqft</td>
           <td></td>
           {{ range $index, $comp := .card.comps }}
           <td>{{ $comp.sale_price_per_sq_ft }}</td>
           {{ end }}
         </tr>
-        <tr class="frozen-row frozen-row-bottom-border">
+        <tr>
           <td class="char-name">Sale Date</td>
           <td></td>
           {{ range $index, $comp := .card.comps }}
           <td>{{ $comp.sale_date }}</td>
           {{ end }}
         </tr>
-        <!-- Metadata rows -->
         <tr>
           <td class="char-name">Sale Doc. Num.</td>
           <td></td>
@@ -373,9 +371,23 @@
         {{ end }}
       </tbody>
       <tfoot>
-          <tr>
-              <th colspan="7" style="text-align:center"><span id="show-more-chars">Show more characteristics</span></th>
-          </tr>
+        <tr>
+          <th>
+            <button type="button" class="btn btn-light" id="show-more">
+              🠛 <strong>Show more</strong> characteristics
+            </button>
+          </th>
+          <th>
+            <button type="button" class="btn btn-light" id="show-less">
+              🠙 <strong>Show fewer</strong> characteristics
+            </button>
+          </th>
+          <th colspan="5" style="text-align:left">
+            <button type="button" class="btn btn-light" id="show-all">
+              🠛 <strong>Show all</strong><br>characteristics
+            </button>
+          </th>
+        </tr>
       </tfoot>
     </table>
   </div>
@@ -687,16 +699,12 @@
       $table.find("tr.frozen-row").remove();
 
       const dt = $table.DataTable({
-        paging: true,
+        paging: false,
         scrollX: true,
         fixedColumns: true,
-        fixedHeader: {
-          header: true,
-          footer: true
-        },
+        fixedHeader: true,
         searching: true,
         info: true,
-        pageLength: 7,
         ordering: true,
         order: [], // Disable default ordering
         lengthChange: false,
@@ -711,17 +719,54 @@
         }
       });
 
-      // Hook into draw event to reinsert frozen rows
-      dt.on("draw.dt", function () {
-        const $tbody = $table.find("tbody");
-        // Reverse the frozen rows array and then prepend each one
-        $($frozenRows.get().reverse()).each(function (i, row) {
-          $tbody.prepend($(row).clone()); // Clone again to avoid duplication issues
+      // Implement custom pagination that is friendlier on mobile
+      const pageSize = 10; // rows per page
+      const totalRows = dt.rows().count();
+      const totalPages = Math.ceil(totalRows / pageSize);
+
+      // Use this global state variable to track page state
+      let visiblePages = 1; // start with the first page
+
+      function updateTable(numPages, size = pageSize) {
+        // Save new page count to state. Avoid mutating this state anywhere
+        // outside this function to reduce the possibility for state-related
+        // bugs
+        visiblePages = numPages;
+        // Show rows if they fit within the current visible pageset
+        dt.rows().every(function(rowIdx, tableLoop, rowLoop) {
+          if (rowIdx < numPages * size) {
+            $(this.node()).show();
+          } else {
+            $(this.node()).hide();
+          }
         });
+        updateButtons(numPages);
+      }
+
+      function updateButtons(numPages) {
+        $("#show-more").prop("disabled", numPages >= totalPages);
+        $("#show-all").prop("disabled", numPages >= totalPages);
+        $("#show-less").prop("disabled", numPages <= 1);
+      }
+
+      $("#show-more").on("click", function() {
+        if (visiblePages < totalPages) {
+          updateTable(visiblePages + 1);
+        }
       });
 
-      // Trigger initial draw (forces first insert)
-      dt.draw();
+      $("#show-all").on("click", function() {
+        updateTable(totalPages);
+      });
+
+      $("#show-less").on("click", function() {
+        if (visiblePages > 1) {
+          updateTable(visiblePages - 1);
+        }
+      });
+
+      // Trigger initial table update
+      updateTable(visiblePages);
     }
   </script>
 </body>

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -295,7 +295,7 @@
   <!-- Comp map -->
   <h2 class="mb-3">Top 5 Most Important Sales</h2>
   <div
-    id="map-{{ if .is_multicard }}{{ .card.card_num }}{{ else }}main{{ end }}"
+    id="map-{{ .card.card_num }}"
     class="map-container"
   >
   </div>
@@ -304,7 +304,7 @@
   <div class="table-responsive mb-2">
     <table
       class="table table-striped table-bordered characteristic-comparison-table"
-      id="comp-table-{{ if .is_multicard }}{{ .card.card_num }}{{ else }}main{{ end }}"
+      id="comp-table-{{ .card.card_num }}"
     >
       <thead>
         <tr>
@@ -373,17 +373,29 @@
       <tfoot>
         <tr>
           <th>
-            <button type="button" class="btn btn-light" id="show-more">
+            <button
+              type="button"
+              class="btn btn-light"
+              id="show-more-{{ .card.card_num }}"
+            >
               🠛 <strong>Show more</strong> characteristics
             </button>
           </th>
           <th>
-            <button type="button" class="btn btn-light" id="show-less">
+            <button
+              type="button"
+              class="btn btn-light"
+              id="show-less-{{ .card.card_num }}"
+            >
               🠙 <strong>Show fewer</strong> characteristics
             </button>
           </th>
           <th colspan="5" style="text-align:left">
-            <button type="button" class="btn btn-light" id="show-all">
+            <button
+              type="button"
+              class="btn btn-light"
+              id="show-all-{{ .card.card_num }}"
+            >
               🠛 <strong>Show all</strong><br>characteristics
             </button>
           </th>
@@ -469,16 +481,11 @@
 
     // Initialize maps once the DOM is loaded
     document.addEventListener("DOMContentLoaded", function() {
-      {{ if $is_multicard }}
-        {{ range $index, $card := .Params.cards }}
-          initializeMap("map-{{ $card.card_num }}", {{ $index }});
-          initializeTable("comp-table-{{ $card.card_num }}");
-        {{ end }}
-        renderMapsOnDisplay(mapRegistry);
-      {{ else }}
-        initializeMap("map-main", 0);
-        initializeTable("comp-table-main");
+      {{ range $index, $card := .Params.cards }}
+        initializeMap("{{ $card.card_num }}", {{ $index }});
+        initializeTable("{{ $card.card_num }}", {{ $index }});
       {{ end }}
+        renderMapsOnDisplay(mapRegistry);
     });
 
     // Fit map bounds only once they are visible. This is important because
@@ -506,14 +513,14 @@
     }
 
     // Initialize map for a specific card
-    function initializeMap(mapId, cardIndex) {
+    function initializeMap(cardNum, cardIndex) {
       const pin = {{ .Params.pin }};
       const pinPretty = {{ .Params.pin_pretty }};
       const mapData = {{ .Params.cards }};
       const cardData = mapData[cardIndex];
 
       // Create map centered on subject property
-      const map = L.map(mapId).setView(
+      const map = L.map(`map-${cardNum}`).setView(
         [cardData.location.loc_latitude, cardData.location.loc_longitude],
         14
       );
@@ -690,9 +697,9 @@
     }
 
     // Initialize the characteristic comparison table
-    function initializeTable(tableId) {
+    function initializeTable(cardNum, cardIndex) {
       // Extract and store frozen rows
-      const $table = $(`#${tableId}`);
+      const $table = $(`#table-${cardNum}`);
       const $frozenRows = $table.find("tr.frozen-row").clone(); // Store clones
 
       // Remove original frozen rows from DOM so they don't get indexed
@@ -719,22 +726,26 @@
         }
       });
 
-      // Implement custom pagination that is friendlier on mobile
+      // Implement custom pagination that is friendlier on mobile.
+      // Start with some constants that we'll use to determine which
+      // rows to show when a user clicks a pagination control button
       const pageSize = 10; // rows per page
       const totalRows = dt.rows().count();
       const totalPages = Math.ceil(totalRows / pageSize);
 
-      // Use this global state variable to track page state
-      let visiblePages = 1; // start with the first page
+      // Use this global state variable to track the page we're on.
+      // Avoid mutating this state anywhere outside the `updateTable()`
+      // function, to reduce to possibility for state-related bugs
+      let visiblePages = 1;
 
-      function updateTable(numPages, size = pageSize) {
-        // Save new page count to state. Avoid mutating this state anywhere
-        // outside this function to reduce the possibility for state-related
-        // bugs
+      // Function to update the visible rows in a table based on a new
+      // pagination request
+      function updateTable(numPages, numRowsPerPage = pageSize) {
+        // Save new page count to state
         visiblePages = numPages;
         // Show rows if they fit within the current visible pageset
         dt.rows().every(function(rowIdx, tableLoop, rowLoop) {
-          if (rowIdx < numPages * size) {
+          if (rowIdx < numPages * numRowsPerPage) {
             $(this.node()).show();
           } else {
             $(this.node()).hide();
@@ -743,23 +754,31 @@
         updateButtons(numPages);
       }
 
+      const $showMoreBtn = $(`#show-more-${card_num}`);
+      const $showAllBtn = $(`#show-all-${card_num}`);
+      const $showLessBtn = $(`#show-less-${card_num}`);
+
+      // Function to update the clickability of pagination buttons depending
+      // on the table state
       function updateButtons(numPages) {
-        $("#show-more").prop("disabled", numPages >= totalPages);
-        $("#show-all").prop("disabled", numPages >= totalPages);
-        $("#show-less").prop("disabled", numPages <= 1);
+        // Don't allow users to show more rows on the last page of rows.
+        // We don't expect `numPages` to ever be greater than `totalPages`,
+        // but handle that possibility defensively in case of bugs
+        $showMoreBtn.prop("disabled", numPages >= totalPages);
+        $showAllBtn.prop("disabled", numPages >= totalPages);
+        // Don't allow users to show fewer rows on the first page of rows
+        $showLessBtn.prop("disabled", numPages <= 1);
       }
 
-      $("#show-more").on("click", function() {
+      $showMoreBtn.on("click", function() {
         if (visiblePages < totalPages) {
           updateTable(visiblePages + 1);
         }
       });
-
-      $("#show-all").on("click", function() {
+      $showAllBtn.on("click", function() {
         updateTable(totalPages);
       });
-
-      $("#show-less").on("click", function() {
+      $showLessBtn.on("click", function() {
         if (visiblePages > 1) {
           updateTable(visiblePages - 1);
         }

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -698,13 +698,7 @@
 
     // Initialize the characteristic comparison table
     function initializeTable(cardNum, cardIndex) {
-      // Extract and store frozen rows
-      const $table = $(`#table-${cardNum}`);
-      const $frozenRows = $table.find("tr.frozen-row").clone(); // Store clones
-
-      // Remove original frozen rows from DOM so they don't get indexed
-      $table.find("tr.frozen-row").remove();
-
+      const $table = $(`#comp-table-${cardNum}`);
       const dt = $table.DataTable({
         paging: false,
         scrollX: true,
@@ -712,8 +706,7 @@
         fixedHeader: true,
         searching: true,
         info: true,
-        ordering: true,
-        order: [], // Disable default ordering
+        ordering: false,
         lengthChange: false,
         language: {
           search: "Filter characteristics:",
@@ -754,18 +747,18 @@
         updateButtons(numPages);
       }
 
-      const $showMoreBtn = $(`#show-more-${card_num}`);
-      const $showAllBtn = $(`#show-all-${card_num}`);
-      const $showLessBtn = $(`#show-less-${card_num}`);
+      const $showMoreBtn = $(`#show-more-${cardNum}`);
+      const $showAllBtn = $(`#show-all-${cardNum}`);
+      const $showLessBtn = $(`#show-less-${cardNum}`);
 
       // Function to update the clickability of pagination buttons depending
       // on the table state
-      function updateButtons(numPages) {
+      function updateButtons(numPages, maxPages = totalPages) {
         // Don't allow users to show more rows on the last page of rows.
         // We don't expect `numPages` to ever be greater than `totalPages`,
         // but handle that possibility defensively in case of bugs
-        $showMoreBtn.prop("disabled", numPages >= totalPages);
-        $showAllBtn.prop("disabled", numPages >= totalPages);
+        $showMoreBtn.prop("disabled", numPages >= maxPages);
+        $showAllBtn.prop("disabled", numPages >= maxPages);
         // Don't allow users to show fewer rows on the first page of rows
         $showLessBtn.prop("disabled", numPages <= 1);
       }

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -15,9 +15,9 @@
 
   <!-- Load Reactable equivalent (DataTables) CSS -->
   <link
-    href="https://cdn.datatables.net/2.3.0/css/dataTables.bootstrap5.min.css"
+    href="https://cdn.datatables.net/2.3.2/css/dataTables.dataTables.min.css"
     rel="stylesheet"
-    integrity="sha384-xkQqWcEusZ1bIXoKJoItkNbJJ1LG5QwR5InghOwFLsCoEkGcNLYjE0O83wWruaK9"
+    integrity="sha384-gC2LYLqCExndkNE9hTLhmEXvk8ZgIf42nRengHFbC9uaws2Ho0TW+ENGe4w15AHy"
     crossorigin="anonymous"
   />
   <link
@@ -26,7 +26,12 @@
     integrity="sha384-hVwUvP9o6t5F4NTn4bygFte7oSFXkYfWMBqENXuJC6xlX2T0lg94klu9D4bHyzUE"
     crossorigin="anonymous"
   />
-  <link rel="stylesheet" href="https://cdn.datatables.net/fixedheader/4.0.3/css/fixedHeader.dataTables.min.css" integrity="sha384-MdjfIsy9elm9qOpK/KXJfYR9PmcQ47vcI0vij5V7nLUOBFvZqPwz0wKJ3q+Sg1RG" crossorigin="anonymous">
+  <link
+    href="https://cdn.datatables.net/fixedheader/4.0.3/css/fixedHeader.dataTables.min.css"
+    rel="stylesheet"
+    integrity="sha384-MdjfIsy9elm9qOpK/KXJfYR9PmcQ47vcI0vij5V7nLUOBFvZqPwz0wKJ3q+Sg1RG"
+    crossorigin="anonymous"
+  />
 
   {{ partial "head/favicons.html" . }}
 
@@ -302,9 +307,9 @@
   </div>
 
   <!-- Comp chars -->
-  <div class="table-responsive mb-2">
+  <div class="mb-2">
     <table
-      class="table table-striped table-bordered characteristic-comparison-table"
+      class="display characteristic-comparison-table"
       id="comp-table-{{ .card.card_num }}"
     >
       <thead>
@@ -467,7 +472,11 @@
     integrity="sha384-pTT0DCmQdJKH1Vz2e0adpu+1Tp4tiIYm+vF6e+b+YAywojOEf3TR2WyIGdICT5Gy"
     crossorigin="anonymous"
   ></script>
-  <script src="https://cdn.datatables.net/fixedheader/4.0.3/js/dataTables.fixedHeader.min.js" integrity="sha384-p66x0SWwSmqfafoeNRyHmaay6Z/zGSRc52U3aGc0gaseU1+CiGgSEyNHTM3gfcqg" crossorigin="anonymous"></script>
+  <script
+    src="https://cdn.datatables.net/fixedheader/4.0.3/js/dataTables.fixedHeader.min.js"
+    integrity="sha384-p66x0SWwSmqfafoeNRyHmaay6Z/zGSRc52U3aGc0gaseU1+CiGgSEyNHTM3gfcqg"
+    crossorigin="anonymous"
+  ></script>
 
   <!-- Main script logic. -->
   <!-- There are two primary steps here: -->
@@ -729,8 +738,13 @@
       const dt = $table.DataTable({
         paging: false,
         scrollX: true,
+        scrollY: "500px",
+        scrollCollapse: true,
         fixedColumns: !L.Browser.mobile,
-        fixedHeader: true,
+        fixedHeader: {
+          header: true,
+          footer: true
+        },
         searching: true,
         info: true,
         ordering: false,
@@ -764,13 +778,11 @@
         // Save new page count to state
         visiblePages = numPages;
         // Show rows if they fit within the current visible pageset
-        dt.rows().every(function(rowIdx, tableLoop, rowLoop) {
-          if (rowIdx < numPages * numRowsPerPage) {
-            $(this.node()).show();
-          } else {
-            $(this.node()).hide();
+        dt.search(
+          function(str, data, rowIdx) {
+            return(rowIdx < numPages * numRowsPerPage)
           }
-        });
+        ).draw();
         updateButtons(numPages);
       }
 
@@ -792,15 +804,62 @@
 
       $showMoreBtn.on("click", function() {
         if (visiblePages < totalPages) {
-          updateTable(visiblePages + 1);
+          const newPageCount = visiblePages + 1;
+          updateTable(newPageCount);
+
+          // After showing more, scroll to the first newly visible row
+          setTimeout(
+            function() {
+              const targetRowIdxOffset = 2
+              const targetRowIdx = ((newPageCount - 1) * pageSize) - targetRowIdxOffset
+              const $targetRow = dt.row(targetRowIdx).node();
+              $targetRow.scrollIntoView({ behavior: "smooth" });
+            },
+            100  // slight delay to ensure DOM is updated
+          );
         }
       });
+
       $showAllBtn.on("click", function() {
-        updateTable(totalPages);
+        const newPageCount = totalPages;
+        updateTable(newPageCount);
+
+        setTimeout(
+          function() {
+            // Scroll to first row in the last page of records in the table.
+            // Subtract 1 to account for the fact that dt.row() uses 0-indexing
+            const targetRowIdx = totalRows - (pageSize + 1);
+            const $targetRow = dt.row(targetRowIdx).node();
+            console.log($targetRow);
+            $targetRow.scrollIntoView({ behavior: "smooth" });
+          },
+          100
+        );
       });
+
       $showLessBtn.on("click", function() {
         if (visiblePages > 1) {
-          updateTable(visiblePages - 1);
+          const oldPageCount = visiblePages;
+          const newPageCount = visiblePages - 1;
+          updateTable(newPageCount);
+
+          setTimeout(
+            function() {
+              // Scroll to first visible row in the new page.
+              // Do this before we update the table so that the scroll
+              // animation is smooth.
+              // Offset by 1 to account for the fact that the sticky header
+              // row will obscure the first row in the table, so we
+              // need to scroll to row N-1 to show row N as the first row.
+              // This offset doesn't work on the first page because we don't
+              // have any rows before the first one, so disable it on that page
+              const targetRowIdxOffset = newPageCount == 1 ? 0 : 2
+              const targetRowIdx = ((newPageCount - 1) * pageSize) - targetRowIdxOffset
+              const $targetRow = dt.row(targetRowIdx).node();
+              $targetRow.scrollIntoView({ behavior: "smooth" });
+            },
+            100
+          );
         }
       });
 

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -20,6 +20,13 @@
     integrity="sha384-xkQqWcEusZ1bIXoKJoItkNbJJ1LG5QwR5InghOwFLsCoEkGcNLYjE0O83wWruaK9"
     crossorigin="anonymous"
   />
+  <link
+    href="https://cdn.datatables.net/fixedcolumns/5.0.4/css/fixedColumns.dataTables.min.css"
+    rel="stylesheet"
+    integrity="sha384-hVwUvP9o6t5F4NTn4bygFte7oSFXkYfWMBqENXuJC6xlX2T0lg94klu9D4bHyzUE"
+    crossorigin="anonymous"
+  />
+  <link rel="stylesheet" href="https://cdn.datatables.net/fixedheader/4.0.3/css/fixedHeader.dataTables.min.css" integrity="sha384-MdjfIsy9elm9qOpK/KXJfYR9PmcQ47vcI0vij5V7nLUOBFvZqPwz0wKJ3q+Sg1RG" crossorigin="anonymous">
 
   {{ partial "head/favicons.html" . }}
 
@@ -365,6 +372,11 @@
         </tr>
         {{ end }}
       </tbody>
+      <tfoot>
+          <tr>
+              <th colspan="7" style="text-align:center"><span id="show-more-chars">Show more characteristics</span></th>
+          </tr>
+      </tfoot>
     </table>
   </div>
 
@@ -425,6 +437,12 @@
     integrity="sha384-G85lmdZCo2WkHaZ8U1ZceHekzKcg37sFrs4St2+u/r2UtfvSDQmQrkMsEx4Cgv/W"
     crossorigin="anonymous"
   ></script>
+  <script
+    src="https://cdn.datatables.net/fixedcolumns/5.0.4/js/dataTables.fixedColumns.min.js"
+    integrity="sha384-pTT0DCmQdJKH1Vz2e0adpu+1Tp4tiIYm+vF6e+b+YAywojOEf3TR2WyIGdICT5Gy"
+    crossorigin="anonymous"
+  ></script>
+  <script src="https://cdn.datatables.net/fixedheader/4.0.3/js/dataTables.fixedHeader.min.js" integrity="sha384-p66x0SWwSmqfafoeNRyHmaay6Z/zGSRc52U3aGc0gaseU1+CiGgSEyNHTM3gfcqg" crossorigin="anonymous"></script>
 
   <!-- Main script logic. -->
   <!-- There are two primary steps here: -->
@@ -670,14 +688,26 @@
 
       const dt = $table.DataTable({
         paging: true,
+        scrollX: true,
+        fixedColumns: true,
+        fixedHeader: {
+          header: true,
+          footer: true
+        },
         searching: true,
-        info: false,
+        info: true,
         pageLength: 7,
         ordering: true,
         order: [], // Disable default ordering
         lengthChange: false,
         language: {
-          search: "Filter characteristics:"
+          search: "Filter characteristics:",
+          info: "Scroll to the right to see more sales ➜"
+        },
+        layout: {
+          topStart: "search",
+          topEnd: L.Browser.mobile ? "info" : null,
+          bottomStart: null
         }
       });
 

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -307,7 +307,7 @@
   </div>
 
   <!-- Comp chars -->
-  <div class="mb-2">
+  <div class="mb-4">
     <table
       class="display characteristic-comparison-table"
       id="comp-table-{{ .card.card_num }}"
@@ -377,33 +377,15 @@
         {{ end }}
       </tbody>
       <tfoot>
-        <tr>
+        <tr class="d-lg-none">
           <th>
-            <button
+            <a
+              href="#sales-summary"
               type="button"
               class="btn btn-light"
-              id="show-more-{{ .card.card_num }}"
             >
-              🠛 <strong>Show more</strong> characteristics
-            </button>
-          </th>
-          <th>
-            <button
-              type="button"
-              class="btn btn-light"
-              id="show-less-{{ .card.card_num }}"
-            >
-              🠙 <strong>Show fewer</strong> characteristics
-            </button>
-          </th>
-          <th colspan="5" style="text-align:left">
-            <button
-              type="button"
-              class="btn btn-light"
-              id="show-all-{{ .card.card_num }}"
-            >
-              🠛 <strong>Show all</strong><br>characteristics
-            </button>
+              🠛 <strong>Skip</strong> to next section
+            </a>
           </th>
         </tr>
       </tfoot>
@@ -418,7 +400,12 @@
   </p>
   {{ end }}
 
-  <h2 class="mb-3">Summary of the Top 5 Most Important Sales</h2>
+  <h2
+    class="mb-3"
+    id="sales-summary"
+  >
+    Summary of the Top 5 Most Important Sales
+  </h2>
   <p>
     The top 5 comparable sales took place
     {{ .card.comp_summary.sale_year_range_prefix }}
@@ -751,120 +738,21 @@
         lengthChange: false,
         language: {
           search: "<b>Search</b> characteristics:",
-          info: "Scroll to the right to see more sales ➜"
+          info: "<span class='d-lg-none'><strong>Scroll right</strong> to see more sales ➜</span>",
+          infoFiltered: "",
+          infoEmpty: "",
         },
         layout: {
-          bottomStart: "search",
-          topEnd: L.Browser.mobile ? "info" : null,
-          topStart: null
-        }
-      });
-
-      // Implement custom pagination that is friendlier on mobile.
-      // Start with some constants that we'll use to determine which
-      // rows to show when a user clicks a pagination control button
-      const pageSize = 10; // rows per page
-      const totalRows = dt.rows().count();
-      const totalPages = Math.ceil(totalRows / pageSize);
-
-      // Use this global state variable to track the page we're on.
-      // Avoid mutating this state anywhere outside the `updateTable()`
-      // function, to reduce to possibility for state-related bugs
-      let visiblePages = 1;
-
-      // Function to update the visible rows in a table based on a new
-      // pagination request
-      function updateTable(numPages, numRowsPerPage = pageSize) {
-        // Save new page count to state
-        visiblePages = numPages;
-        // Show rows if they fit within the current visible pageset
-        dt.search(
-          function(str, data, rowIdx) {
-            return(rowIdx < numPages * numRowsPerPage)
-          }
-        ).draw();
-        updateButtons(numPages);
-      }
-
-      const $showMoreBtn = $(`#show-more-${cardNum}`);
-      const $showAllBtn = $(`#show-all-${cardNum}`);
-      const $showLessBtn = $(`#show-less-${cardNum}`);
-
-      // Function to update the clickability of pagination buttons depending
-      // on the table state
-      function updateButtons(numPages, maxPages = totalPages) {
-        // Don't allow users to show more rows on the last page of rows.
-        // We don't expect `numPages` to ever be greater than `totalPages`,
-        // but handle that possibility defensively in case of bugs
-        $showMoreBtn.prop("disabled", numPages >= maxPages);
-        $showAllBtn.prop("disabled", numPages >= maxPages);
-        // Don't allow users to show fewer rows on the first page of rows
-        $showLessBtn.prop("disabled", numPages <= 1);
-      }
-
-      $showMoreBtn.on("click", function() {
-        if (visiblePages < totalPages) {
-          const newPageCount = visiblePages + 1;
-          updateTable(newPageCount);
-
-          // After showing more, scroll to the first newly visible row
-          setTimeout(
-            function() {
-              const targetRowIdxOffset = 2
-              const targetRowIdx = ((newPageCount - 1) * pageSize) - targetRowIdxOffset
-              const $targetRow = dt.row(targetRowIdx).node();
-              $targetRow.scrollIntoView({ behavior: "smooth" });
-            },
-            100  // slight delay to ensure DOM is updated
-          );
-        }
-      });
-
-      $showAllBtn.on("click", function() {
-        const newPageCount = totalPages;
-        updateTable(newPageCount);
-
-        setTimeout(
-          function() {
-            // Scroll to first row in the last page of records in the table.
-            // Subtract 1 to account for the fact that dt.row() uses 0-indexing
-            const targetRowIdx = totalRows - (pageSize + 1);
-            const $targetRow = dt.row(targetRowIdx).node();
-            console.log($targetRow);
-            $targetRow.scrollIntoView({ behavior: "smooth" });
+          topStart: "search",
+          topEnd: "info",
+          bottomStart: {
+            div: {
+              html: "🠛 <strong>Scroll down</strong> on the table to see more characteristics",
+              className: "d-none d-lg-block"
+            }
           },
-          100
-        );
-      });
-
-      $showLessBtn.on("click", function() {
-        if (visiblePages > 1) {
-          const oldPageCount = visiblePages;
-          const newPageCount = visiblePages - 1;
-          updateTable(newPageCount);
-
-          setTimeout(
-            function() {
-              // Scroll to first visible row in the new page.
-              // Do this before we update the table so that the scroll
-              // animation is smooth.
-              // Offset by 1 to account for the fact that the sticky header
-              // row will obscure the first row in the table, so we
-              // need to scroll to row N-1 to show row N as the first row.
-              // This offset doesn't work on the first page because we don't
-              // have any rows before the first one, so disable it on that page
-              const targetRowIdxOffset = newPageCount == 1 ? 0 : 2
-              const targetRowIdx = ((newPageCount - 1) * pageSize) - targetRowIdxOffset
-              const $targetRow = dt.row(targetRowIdx).node();
-              $targetRow.scrollIntoView({ behavior: "smooth" });
-            },
-            100
-          );
         }
       });
-
-      // Trigger initial table update
-      updateTable(visiblePages);
     }
   </script>
 </body>

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -377,15 +377,18 @@
         {{ end }}
       </tbody>
       <tfoot>
-        <tr class="d-lg-none">
+        <tr>
           <th>
             <a
               href="#sales-summary"
               type="button"
               class="btn btn-light"
             >
-              🠛 <strong>Skip</strong> to next section
+              ▼ Skip to next section
             </a>
+          </th>
+          <th colspan="6" style="font-weight: normal" >
+            🠛 Scroll down on the table to see more characteristics
           </th>
         </tr>
       </tfoot>
@@ -723,34 +726,28 @@
     function initializeTable(cardNum, cardIndex) {
       const $table = $(`#comp-table-${cardNum}`);
       const dt = $table.DataTable({
-        paging: false,
-        scrollX: true,
-        scrollY: "500px",
-        scrollCollapse: true,
-        fixedColumns: !L.Browser.mobile,
+        paging: false,  // Disable pagination to display all chars at once
+        scrollX: true,  // Allow the table to scroll horizontally on narrow screens
+        scrollY: "500px",  // Force the table to scroll vertically with a fixed height
+        scrollCollapse: true,  // Collapse the table size below the fixed height when there are few rows
+        fixedColumns: true,  // Freeze the leftmost column (chars) during horizontal scroll
         fixedHeader: {
-          header: true,
-          footer: true
+          header: true,  // Make the header row sticky during scroll
+          footer: true  // Make the footer sticky during scroll
         },
-        searching: true,
-        info: true,
-        ordering: false,
-        lengthChange: false,
-        language: {
-          search: "<b>Search</b> characteristics:",
-          info: "<span class='d-lg-none'><strong>Scroll right</strong> to see more sales ➜</span>",
-          infoFiltered: "",
-          infoEmpty: "",
+        searching: true,  // Enable a search box to filter rows
+        info: true,  // Enable info text (defined under the `language` key below)
+        ordering: false,  // Disable sorting by column
+        language: {  // Custom text
+          search: "<b>Search</b> characteristics:",  // Search input label
+          info: "<span class='d-lg-none'>Scroll right to see more sales ➜</span>",
+          infoFiltered: "",  // Disable searched row count text
+          infoEmpty: "",  // Disable text that shows when no rows match search
         },
         layout: {
-          topStart: "search",
-          topEnd: "info",
-          bottomStart: {
-            div: {
-              html: "🠛 <strong>Scroll down</strong> on the table to see more characteristics",
-              className: "d-none d-lg-block"
-            }
-          },
+          topStart: "search",  // Top left: Search box
+          topEnd: "info",  // Top right: Horizontal scroll prompt
+          bottomStart: null,  // Disable bottom text, since we use a frozen footer
         }
       });
     }


### PR DESCRIPTION
This PR is a companion to https://github.com/ccao-data/pinval/pull/90, implementing similar UX improvements for the characteristic comparison table that sits below the sales map.

The PR makes the following improvements to the table UX:

* Removes pagination and instead makes the characteristics table scrollable
* Adds a "scroll down to see more characteristics" prompt to the bottom of the table, to provide a hint to users
* Freezes the header row so that it follows the page as the user scrolls in case the full table is not in the user's viewport
    * This frozen row replaces the three rows that we have been artificially freezing using custom JavaScript (sale price, sale $/sqft, and sale doc no). While It would be nice to freeze these rows as well, it's not feasible to do
* Freezes the leftmost column ("Characteristic") so that if the user has to scroll horizontally they can always see the name of the characteristic
* On mobile, adds a "skip to next section" button to the table footer and makes that footer sticky so that users don't have to scroll the full table vertically in order to move onto the next section
    * This is important on mobile because the table takes up the full width of the viewport on mobile, meaning the user doesn't have the option to scroll _outside_ the table to scroll past it
* On narrow viewport sizes where the table is horizontally scrollable, adds a prompt to "scroll right to see more sales"
* Changes the table style to use the default DataTables style instead of the DataTables Bootstrap style, since I think the DataTables style is cleaner