### PR TITLE
Add "Back to search" button option

### DIFF
--- a/.github/workflows/generate-pinval.yaml
+++ b/.github/workflows/generate-pinval.yaml
@@ -207,12 +207,14 @@ jobs:
       - name: Generate PINVAL reports
         env:
           RUN_ID: ${{ needs.setup.outputs.run-id }}
+          ENV_CODE: ${{ inputs.environment == 'Production bucket' && 'prod' || 'dev' }}
         run: |
           read -ra PINS <<< "${{ inputs.pins }}"
           python3 scripts/generate_pinval/generate_pinval.py \
             --run-id "$RUN_ID" \
             --township "$TOWNSHIP" \
-            --pin "${PINS[@]}"
+            --pin "${PINS[@]}" \
+            --environment "$ENV_CODE"
 
       - name: Sync reports to S3
         env:

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -32,7 +32,7 @@
   <div class="container">
 
     <div class="card-body">
-    <!-- Search again button that returns use to homepage -->
+    <!-- Search again button that returns user to homepage -->
     <p>
       {{- /* Determine the search‑page URL based on environment */ -}}
       {{ $searchHref := cond (eq .Params.environment "prod") "." "https://stage-drupal.ccaotest.com/model-valuation" }}

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -30,7 +30,16 @@
 
   <!-- Body of the report -->
   <div class="container">
+
     <div class="card-body">
+    <!-- Search again button that returns use to homepage -->
+    <p>
+      {{- /* Determine the search‑page URL based on environment */ -}}
+      {{ $searchHref := cond (eq .Params.environment "prod") "." "https://stage-drupal.ccaotest.com/model-valuation" }}
+      <a href="{{ $searchHref }}" class="text-decoration-none fw-semibold">
+        ⬅Search again
+      </a>
+    </p>
 
       <!-- Contextual information -->
       <p>

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -35,8 +35,8 @@
     <!-- Search again button that returns user to homepage -->
     <p>
       {{- /* Determine the search‑page URL based on environment */ -}}
-      {{ $searchHref := cond (eq .Params.environment "prod") "." "https://stage-drupal.ccaotest.com/model-valuation" }}
-      <a href="{{ $searchHref }}" class="text-decoration-none fw-semibold">
+      {{ $search_href := cond (eq .Params.environment "prod") "." "https://stage-drupal.ccaotest.com/model-valuation" }}
+      <a href="{{ $search_ref }}" class="text-decoration-none fw-semibold">
         ⬅Search again
       </a>
     </p>

--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -37,7 +37,7 @@
       {{- /* Determine the search‑page URL based on environment */ -}}
       {{ $search_href := cond (eq .Params.environment "prod") "." "https://stage-drupal.ccaotest.com/model-valuation" }}
       <a href="{{ $search_ref }}" class="text-decoration-none fw-semibold">
-        ⬅Search again
+        ⬅Back to Search
       </a>
     </p>
 

--- a/scripts/generate_pinval/generate_pinval.py
+++ b/scripts/generate_pinval/generate_pinval.py
@@ -83,6 +83,13 @@ def parse_args() -> argparse.Namespace:
         ),
     )
 
+    parser.add_argument(
+        "--environment",
+        choices=["dev", "prod"],
+        default="dev",
+        help="Deployment target",
+    )
+
     args = parser.parse_args()
 
     if args.pin == [""]:
@@ -147,6 +154,7 @@ def build_front_matter(
     df_target_pin: pd.DataFrame,
     df_comps: pd.DataFrame,
     pretty_fn: typing.Callable[[str], str],
+    environment: str,
 ) -> dict:
     """
     Assemble the front-matter dict for **one PIN**.
@@ -186,6 +194,7 @@ def build_front_matter(
         "cards": [],
         "var_labels": {k: pretty_fn(k) for k in preds_cleaned},
         "special_case_multi_card": special_multi,
+        "environment": environment,
     }
 
     # Exit early if this PIN is ineligible for a report, in which case we
@@ -647,7 +656,12 @@ def main() -> None:
 
         df_comps = df_comps_by_pin.get(pin)
 
-        front = build_front_matter(df_target, df_comps, pretty_fn=pretty)
+        front = build_front_matter(
+            df_target,
+            df_comps,
+            pretty_fn=pretty,
+            environment=args.environment,
+        )
         front["url"] = f"/{assessment_year}/{pin}.html"
 
         write_json(front, md_path)


### PR DESCRIPTION
This PR adds a "back to search" button which functions like a back button, linking back to the home page of the model report website where the user can search for a year and pin. It adds an `environment` flag to the script, which allows us to specify if we want to switch back to the dev or prod version of the website.

Dev pin: 01031000380000

Closes https://github.com/ccao-data/pinval/issues/84