### PR TITLE
Add PIN detail links to the sales characteristics table

### DIFF
--- a/hugo/layouts/report.html
+++ b/hugo/layouts/report.html
@@ -471,9 +471,17 @@
         </tr>
         <tr>
           <td class="char-name">PIN</td>
-          <td>{{ $.card.pin_pretty }}</td>
+          <td>
+            <a href="https://www.cookcountyassessor.com/pin/{{ .Params.pin }}" target="_blank">
+              {{ .card.pin_pretty }}
+            </a>
+          </td>
           {{ range $comp := $.card.comps }}
-            <td>{{ $comp.pin_pretty }}</td>
+            <td>
+              <a href="https://www.cookcountyassessor.com/pin/{{ $comp.pin }}" target="_blank">
+                {{ $comp.pin_pretty }}
+              </a>
+            </td>
           {{ end }}
         </tr>
         <!-- Regular rows -->


### PR DESCRIPTION
This tiny PR adds links to the "PIN" feature row in the sales characteristics table so that users can click on a PIN to see more details from the context of the table.

Closes #99. 