### PR TITLE
Fix report generation for condo PINs

### DIFF
--- a/scripts/generate_pinval/generate_pinval.py
+++ b/scripts/generate_pinval/generate_pinval.py
@@ -187,7 +187,9 @@ def build_front_matter(
         "assessment_year": tp["assessment_year"],
         "final_model_run_date": pd.to_datetime(tp["final_model_run_date"]).strftime(
             "%B %d, %Y"
-        ),
+        )
+        if tp["final_model_run_date"]
+        else None,
         "pin": tp["meta_pin"],
         "pin_pretty": pin_pretty(tp["meta_pin"]),
         "pred_pin_final_fmv_round": tp["pred_pin_final_fmv_round"],


### PR DESCRIPTION
I noticed while reviewing https://github.com/ccao-data/pinval/pull/109 that report generation fails for condo PINs because they no longer have final model run dates following https://github.com/ccao-data/data-architecture/pull/864, so this block raises an error:

https://github.com/ccao-data/pinval/blob/bf4ff82dac74adf01d8be7934411e11b3156ee5c/scripts/generate_pinval/generate_pinval.py#L188-L190

This PR resolves the error by tweaking this block so that we only parse the date if one exists.

I tested by generating a report for a random condo PIN locally:

```
python3 ../scripts/generate_pinval/generate_pinval.py --run-id 2025-04-25-fancy-free-billy --pin 20101140291011 --skip-html
```