### PR TITLE
Update social card with new report name

### DIFF
--- a/hugo/layouts/_partials/head/boilerplate.html
+++ b/hugo/layouts/_partials/head/boilerplate.html
@@ -5,7 +5,7 @@
 <title>{{ .Title }}</title>
 
 {{ $social_card_url := "/static/images/social-card.jpg" }}
-{{ $social_card_title := "Cook County Assessor's Model Value Report"}}
+{{ $social_card_title := "Cook County Assessor's Home Value Report"}}
 {{
   $social_card_description := (
     cond (and .Params.pin .Params.assessment_year)


### PR DESCRIPTION
This PR updates the social cards we added in #115 to reflect the new name for the reports.

To test, enter the staging site link for PIN 01011000040000 into a Teams chat with yourself, which will render the text that we changed here as the title. You can also test the PIN on https://metatags.io/ though you should note that most social platforms do not actually display the title that we are changing here, hence that website is not particularly useful for testing in this case.