### PR TITLE
Add a flag to only build and deploy report-eligible PINs

### DIFF
--- a/.github/workflows/generate-pinval.yaml
+++ b/.github/workflows/generate-pinval.yaml
@@ -64,7 +64,7 @@ on:
       eligible-only:
         type: boolean
         description: >
-          Only generate reports for PINs where is_report_eligible = true
+          Only generate reports for PINs that are eligible for reports (i.e. no error pages)
         required: false
         default: true
 

--- a/.github/workflows/generate-pinval.yaml
+++ b/.github/workflows/generate-pinval.yaml
@@ -61,6 +61,13 @@ on:
         required: false
         default: false
 
+      eligible-only:
+        type: boolean
+        description: >
+          Only generate reports for PINs where is_report_eligible = true
+        required: false
+        default: true
+
 env:
   PYTHONUNBUFFERED: "1"
   UV_SYSTEM_PYTHON: 1
@@ -222,6 +229,10 @@ jobs:
           if [ "${{ inputs.hugo-build-by-nbhd }}" = "true" ]; then
             NBHD_FLAG="--build-by-neighborhood"
           fi
+          ELIG_FLAG=""
+          if [ "${{ inputs.eligible-only }}" = "true" ]; then
+            ELIG_FLAG="--eligible-only"
+          fi
           # Unquoted neighborhood flag is intentional in this call, since we
           # want this to expand to nothing (rather than an empty string) if
           # the variable is empty
@@ -230,7 +241,8 @@ jobs:
             --township "$TOWNSHIP" \
             --pin "${PINS[@]}" \
             --environment "$ENV_CODE" \
-            $NBHD_FLAG
+            $NBHD_FLAG \
+            $ELIG_FLAG
 
       - name: Sync reports to S3
         env:

--- a/.github/workflows/generate-pinval.yaml
+++ b/.github/workflows/generate-pinval.yaml
@@ -66,7 +66,7 @@ on:
         description: >
           Only generate reports for PINs that are eligible for reports (i.e. no error pages)
         required: false
-        default: true
+        default: false
 
 env:
   PYTHONUNBUFFERED: "1"

--- a/scripts/generate_pinval/generate_pinval.py
+++ b/scripts/generate_pinval/generate_pinval.py
@@ -94,6 +94,16 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--eligible-only",
+        action="store_true",
+        help=(
+            "When present, restricts the assessment query to PINs where "
+            "is_report_eligible = true to avoid generating static pages for "
+            "ineligible parcels."
+        ),
+    )
+
+    parser.add_argument(
         "--build-by-neighborhood",
         action="store_true",
         help=(
@@ -701,6 +711,9 @@ def main() -> None:
 
         assessment_clauses.append(f"meta_pin IN ({placeholders})")
         params_assessment = {**params_assessment, **pin_params}
+
+    if args.eligible_only:
+        assessment_clauses.append("is_report_eligible = TRUE")
 
     where_assessment = " AND ".join(assessment_clauses)
 


### PR DESCRIPTION
This PR adds a flag that allows us to optionally build _only report-eligible_ PINs on deploy, allowing us to save time and compute when we aren't concerned with making changes to things like error pages.


Some local testing confirms it works. This code only produces the two 2025 markdown files, since the other 2024 PINs aren't report eligible for the 2025 assessment year.

```bash
python3 generate_pinval.py --run-id 2025-04-25-fancy-free-billy --pin 10314090100000 16251250220000 05271130010000 01011240390000 --skip-html --eligible-only
```

2024 | 10314090100000
2024 | 16251250220000
2025 | 05271130010000
2025 | 01011240390000

Closes #123 

