### PR TITLE
Fix `eligible-only` workflow flag by filtering out non-eligible towns

### DIFF
--- a/.github/workflows/generate-pinval.yaml
+++ b/.github/workflows/generate-pinval.yaml
@@ -134,12 +134,17 @@ jobs:
           # both arguments
           read -ra PINS <<< "${{ inputs.pins }}"
           read -ra TOWNSHIPS <<< "${{ inputs.townships }}"
+          ELIG_FLAG=""
+          if [ "${{ inputs.eligible-only }}" = "true" ]; then
+            ELIG_FLAG="--eligible-only"
+          fi
           python3 scripts/generate_pinval/resolve_model_metadata.py \
             --year "${{ inputs.year }}" \
             --run-id "${{ inputs.run_id }}" \
             --pin "${PINS[@]}" \
             --township "${TOWNSHIPS[@]}" \
-            --write-github-output
+            --write-github-output \
+            $ELIG_FLAG
 
       - name: Resolve AWS resources
         id: resolve-aws


### PR DESCRIPTION
Hotfix building on top of https://github.com/ccao-data/pinval/pull/128. The version of the code in that PR raises an error when trying to build towns that have no eligible reports.

See here for an example of a failing workflow run: https://github.com/ccao-data/pinval/actions/runs/17508784393

Successful workflow run after incorporating these changes: https://github.com/ccao-data/pinval/actions/runs/17509317491