### PR TITLE
Pin `generate-homeval` workflow Python dependencies to lockfile

### DIFF
--- a/.github/workflows/generate-homeval.yaml
+++ b/.github/workflows/generate-homeval.yaml
@@ -117,7 +117,7 @@ jobs:
           python-version-file: scripts/generate_homeval/.python-version
 
       - name: Install Python requirements
-        run: uv pip install .
+        run: uv sync --frozen
         working-directory: scripts/generate_homeval
 
       - name: Configure AWS credentials (OIDC)
@@ -198,7 +198,7 @@ jobs:
           python-version-file: scripts/generate_homeval/.python-version
 
       - name: Install Python requirements
-        run: uv pip install .
+        run: uv sync --frozen
         working-directory: scripts/generate_homeval
 
       - name: Configure AWS credentials (OIDC)

--- a/.github/workflows/generate-homeval.yaml
+++ b/.github/workflows/generate-homeval.yaml
@@ -70,7 +70,6 @@ on:
 
 env:
   PYTHONUNBUFFERED: "1"
-  UV_SYSTEM_PYTHON: 1
   AWS_REGION: us-east-1
   AWS_ATHENA_S3_STAGING_DIR: s3://ccao-athena-results-us-east-1/
   HUGO_VERSION: "0.147.5"
@@ -138,7 +137,10 @@ jobs:
           if [ "${{ inputs.eligible-only }}" = "true" ]; then
             ELIG_FLAG="--eligible-only"
           fi
-          python3 scripts/generate_homeval/resolve_model_metadata.py \
+          uv run \
+            --frozen \
+            --project scripts/generate_homeval \
+            python3 scripts/generate_homeval/resolve_model_metadata.py \
             --year "${{ inputs.year }}" \
             --run-id "${{ inputs.run_id }}" \
             --pin "${PINS[@]}" \
@@ -241,7 +243,10 @@ jobs:
           # Unquoted neighborhood flag is intentional in this call, since we
           # want this to expand to nothing (rather than an empty string) if
           # the variable is empty
-          python3 scripts/generate_homeval/generate_homeval.py \
+          uv run \
+            --frozen \
+            --project scripts/generate_homeval \
+            python3 scripts/generate_homeval/generate_homeval.py \
             --run-id "$RUN_ID" \
             --township "$TOWNSHIP" \
             --pin "${PINS[@]}" \


### PR DESCRIPTION
It turns out the command we use to install Python dependencies in the `generate-homeval` workflow (`uv pip install .`) will ignore a `uv.lock` file and install dependency versions as listed in `pyproject.toml` instead. This is causing [the workflow to fail](https://github.com/ccao-data/homeval/actions/runs/23563619035/job/68609593810#step:11:63) due to a breaking change in a recent pandas version.

I was able to get the workflow working again by switching the install step to use [`uv sync` and `uv run`](https://docs.astral.sh/uv/guides/integration/github/#syncing-and-running) so that uv will use the exact dependency versions listed in `uv.lock`.

These changes led to a successful staging build whose logs you can inspect [here](https://github.com/ccao-data/homeval/actions/runs/23384211662). The changes might be confusing if you're not used to working with uv, so I'm happy to talk them through out loud if it would be helpful.