### PR TITLE
Bump hugo version to v0.159.2

### DIFF
--- a/.github/workflows/generate-homeval.yaml
+++ b/.github/workflows/generate-homeval.yaml
@@ -72,7 +72,7 @@ env:
   PYTHONUNBUFFERED: "1"
   AWS_REGION: us-east-1
   AWS_ATHENA_S3_STAGING_DIR: s3://ccao-athena-results-us-east-1/
-  HUGO_VERSION: "0.147.5"
+  HUGO_VERSION: "0.159.2"
 
 defaults:
   run:


### PR DESCRIPTION
Dev pin on staging: 01011000040000.

Static assets deployed, logs: https://github.com/ccao-data/homeval/actions/runs/24784331836/job/72524026175

Closes https://github.com/ccao-data/homeval/issues/159