### PR TITLE
Fix venv setup instructions to make sure we use uv lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ Start by creating a virtual environment for the script and installing its
 dependencies:
 
 ```
-uv venv scripts/generate_homeval/.venv
-source scripts/generate_homeval/.venv/bin/activate
-uv pip install scripts/generate_homeval
+cd scripts/generate_homeval
+uv sync --frozen
+source .venv/bin/activate
+cd ../..
 ```
 
 Then, use the script to generate reports for one or more PINs using a given


### PR DESCRIPTION
In https://github.com/ccao-data/homeval/pull/158 we tweaked the `generate-homeval` workflow to ensure it installs the exact Python package versions listed in `scripts/generate_homeval/uv.lock`, but we didn't touch the setup instructions in the README, so those instructions continue to list installation commands that will ignore the lockfile. This PR tweaks those instructions to make sure the commands install the package versions listed in the uv lockfile.

I tested this change by removing my virtualenv, following the new instructions to recreate it, and confirming that A) the package versions match the lockfile and B) a `generate_homeval.py` call continues to work:

```bash
cd scripts/generate_homeval
rm -rf .venv
uv sync --frozen
source .venv/bin/activate
cd ../..
python3 scripts/generate_homeval/generate_homeval.py --run-id 2025-06-14-flamboyant-rob --pin 01011000040000 10112040080000
```