### PR TITLE
Upgrade all third-party actions and pin them to immutable releases

### DIFF
--- a/.github/workflows/generate-homeval.yaml
+++ b/.github/workflows/generate-homeval.yaml
@@ -99,19 +99,19 @@ jobs:
       distribution-id: ${{ steps.resolve-aws.outputs.distribution-id }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Mask sensitive information
         run: echo "::add-mask::${{ secrets.AWS_ACCOUNT_ID }}"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: scripts/generate_homeval/uv.lock
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version-file: scripts/generate_homeval/.python-version
 
@@ -120,7 +120,7 @@ jobs:
         working-directory: scripts/generate_homeval
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
           aws-region: us-east-1
@@ -183,19 +183,19 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Mask sensitive information
         run: echo "::add-mask::${{ secrets.AWS_ACCOUNT_ID }}"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: scripts/generate_homeval/uv.lock
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version-file: scripts/generate_homeval/.python-version
 
@@ -204,7 +204,7 @@ jobs:
         working-directory: scripts/generate_homeval
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
           aws-region: us-east-1
@@ -212,7 +212,7 @@ jobs:
 
       - name: Cache Hugo package
         id: cache-hugo
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ runner.temp }}/hugo.deb
           key: hugo-deb-${{ env.HUGO_VERSION }}
@@ -283,7 +283,7 @@ jobs:
       id-token: write
     steps:
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Run pre-commit checks
         uses: ccao-data/actions/pre-commit@main


### PR DESCRIPTION
This PR upgrades all of our third-party GitHub Actions to ensure they are compatible with the [upcoming Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

While we're at it, we also switch all of our references to third-party actions to point to immutable releases, so as to protect ourselves from the the ongoing scourge of supply chain attacks against third-party actions. If an action repo is using [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases), we pin to a specific immutable release; otherwise, we pin to the commit hash for the latest release of that action.

Test workflows to confirm these upgrades don't break anything:

- [x] `pre-commit`: https://github.com/ccao-data/homeval/actions/runs/26239715613/job/77222477440
- [x] `generate-homeval`: https://github.com/ccao-data/homeval/actions/runs/26239864563

Connects https://github.com/ccao-data/aws-infrastructure/issues/59.